### PR TITLE
Handling for $PATH or %PATH% in texpath

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 fs = require 'fs'
 {parse_tex_log} = require './parsers/parseTeXLog'
 parse_tex_directives = require './parsers/tex-directive-parser'
+{expand_variables} = require './utils/expand-vars'
 
 module.exports =
 
@@ -106,19 +107,14 @@ class Builder extends LTool
 
     # Now prepare path
     # TODO: also env if needed
-    # Note: texpath must NOT include $PATH!!!
 
-    # Apparently the key is different on Win and non-Win
-    if process.platform == "win32"
-      current_path = process.env.Path
-    else
-      current_path = process.env.PATH
     texpath = atom.config.get("latextools." + process.platform + ".texpath")
     @ltConsole.addContent("Platform: #{process.platform}; texpath: #{texpath}")
-    cmd_env = process.env
+    # shallow-copy
+    cmd_env = Object.create process.env
     if texpath
-      cmd_env.PATH = current_path + path.delimiter + texpath
-      @ltConsole.addContent("setting PATH = #{process.env.PATH}")
+      cmd_env.PATH = expand_variables(texpath)
+      @ltConsole.addContent("setting PATH = #{cmd_env.PATH}")
 
     @ltConsole.addContent("Processing file #{filebase} (#{filename}) in directory #{filedir}",br=true)
 

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -83,7 +83,7 @@ module.exports = Latextools =
       properties:
         texpath:
           type: 'string'
-          default: "/Library/TeX/texbin:/usr/texbin:/usr/local/bin:/opt/local/bin"
+          default: "/Library/TeX/texbin:/usr/texbin:/usr/local/bin:/opt/local/bin:$PATH"
       order: 13
 
     win32:
@@ -106,6 +106,7 @@ module.exports = Latextools =
           type: 'number'
           default: 0.5
       order:14
+
     linux:
       type: 'object'
       properties:

--- a/lib/utils/expand-vars.coffee
+++ b/lib/utils/expand-vars.coffee
@@ -1,0 +1,24 @@
+module.exports =
+  expand_variables: (str) ->
+    return str if typeof(str) is not "string"
+
+    # on Windows, environment variables are not case-sensitive
+    # on POSIX, they are
+    flags = if process.platform is 'win32'
+      'gi'
+    else
+      'g'
+
+    for key of process.env
+      str = str.replace(
+        new RegExp("\\$\\{?#{key}\\}?", flags)
+        process.env[key]
+      )
+
+      if process.platform is 'win32'
+        str = str.replace(
+          new RegExp("%#{key}%", flags)
+          process.env[key]
+        )
+
+    return str

--- a/spec/spec-helpers.coffee
+++ b/spec/spec-helpers.coffee
@@ -1,0 +1,16 @@
+module.exports =
+  mockPlatform: (platform) ->
+    beforeEach ->
+      @originalPlatform = process.platform
+      Object.defineProperty process, 'platform', value: platform
+
+    afterEach ->
+      Object.defineProperty process, 'platform', value: @originalPlatform
+
+  mockEnvVar: (variable, value) ->
+    beforeEach ->
+      @originalValue = process.env[variable]
+      Object.defineProperty process.env, variable, value: value
+
+    afterEach ->
+      Object.defineProperty process.env, variable, value: @originalValue

--- a/spec/utils/expand-vars-spec.coffee
+++ b/spec/utils/expand-vars-spec.coffee
@@ -1,0 +1,55 @@
+{expand_variables} = require '../../lib/utils/expand-vars'
+{mockPlatform, mockEnvVar} = require '../spec-helpers'
+
+describe 'expand_variables', ->
+  it 'should expand Unix-style variables', ->
+    str = '$PATH'
+    expectedPath = process.env.PATH
+    expect(expand_variables(str)).toBe expectedPath
+
+  it 'should expand Unix-style variables wrapped in brackets', ->
+    str = '${PATH}'
+    expectedPath = process.env.PATH
+    expect(expand_variables(str)).toBe expectedPath
+
+  it 'should expand Unix-style variables when embedded in string', ->
+    str = '/foo:$PATH:/bar'
+    expectedPath = str.replace('$PATH', process.env.PATH)
+    expect(expand_variables(str)).toBe expectedPath
+
+  it 'should do nothing if string contains no variables', ->
+    str = '/foo:/bar'
+    expect(expand_variables(str)).toBe str,
+
+  it 'should replace multiple tokens', ->
+    str = '$PATH:/foo/:$PATH:/bar'
+    expectedPath = str.replace(/\$PATH/g, process.env.PATH)
+    expect(expand_variables(str)).toBe expectedPath
+
+  describe 'Windows-specific behavior', ->
+    mockPlatform('win32')
+
+    it 'should expand Windows-style variables on Windows', ->
+      str = '%PATH%'
+      expectedPath = process.env.PATH
+      expect(expand_variables(str)).toBe expectedPath
+
+    it 'should expand Windows-style variables when embedded in string', ->
+      str = '/foo;%PATH%;/bar'
+      expectedPath = str.replace('%PATH%', process.env.PATH)
+      expect(expand_variables(str)).toBe expectedPath
+
+    it 'should replace multiple Windows-style variables', ->
+      str = '%PATH%:/foo/:%PATH%:/bar'
+      expectedPath = str.replace(/%PATH%/g, process.env.PATH)
+      expect(expand_variables(str)).toBe expectedPath
+
+    it 'should not be case-sensitive on Windows', ->
+      str = '/foo:$PaTh:/bar'
+      expectedPath = str.replace(/\$PATH/gi, process.env.PATH)
+      expect(expand_variables(str)).toBe expectedPath
+
+    it 'should not be case-sensitive with Windows-style variables', ->
+      str = '/foo;%PaTh%;/bar'
+      expectedPath = str.replace(/%PATH%/gi, process.env.PATH)
+      expect(expand_variables(str)).toBe expectedPath


### PR DESCRIPTION
This makes `texpath` work like on Sublime Text, i.e., it allows the specification of `texpath` to include either `$PATH$ or `%PATH%` using a (rough) equivalent to Python's `os.path.expandpath()`.