### PR TITLE
Fix multiple options for latexmk

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -28,8 +28,10 @@ class Builder extends LTool
     user_program = 'pdf' if user_program is 'pdflatex'
 
     options =  ["-cd", "-e", "-f", "-#{user_program}",
-      "-interaction=nonstopmode", "-synctex=1"]\
-        .concat ["-latexoption=\"#{texopt}\"" for texopt in user_options]
+      "-interaction=nonstopmode", "-synctex=1"]
+
+    for texopt in user_options
+      options.push "-latexoption=#{texopt}"
 
     command = ["latexmk"].concat(options, "\"#{texfile}\"").join(' ')
     @ltConsole.addContent(command,br=true)

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -31,7 +31,7 @@ class Builder extends LTool
       "-interaction=nonstopmode", "-synctex=1"]
 
     for texopt in user_options
-      options.push "-latexoption=#{texopt}"
+      options.push "-latexoption=\"#{texopt}\""
 
     command = ["latexmk"].concat(options, "\"#{texfile}\"").join(' ')
     @ltConsole.addContent(command,br=true)


### PR DESCRIPTION
The comments on #3 made me realise that user_options still wasn't working as expected on latexmk. Basically with multiple options is was getting a command line like:

`latexmk -cd -e -f -pdf -interaction=nonstopmode -synctex=1 -latexoption="first_option",-latexoption="second_option" file.tex`

While the options showed up, they weren't being honoured. Digging into it, it appeared that options was being set to `["-cd", "-e", "-f", "-#{user_program}", "-interaction=nonstopmode", "-synctex=1", ["-latexmk=\"first_option\"", "-latexmk=\"second_option\""]]`, hence the bad behaviour. This PR fixes that.