### PR TITLE
fixed missing "view" errors under windows

### DIFF
--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -20,7 +20,7 @@ class Viewer extends LTool
     @ltConsole.addContent("Executing " + command, br = true)
 
     exec command, {}, (err, stdout, stderr) =>
-      if err # weirdness
+      if err && !(err.code == 1 && !stderr) # when it is already running, Sumatra returns error code 1 but no error message, while "the jump" works just fine
         @ltConsole.addContent("ERROR #{err.code}: ", br=true)
         @ltConsole.addContent(line, br=true) for line in stderr.split('\n')
 

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -20,7 +20,7 @@ class Viewer extends LTool
     @ltConsole.addContent("Executing " + command, br = true)
 
     exec command, {}, (err, stdout, stderr) =>
-      if err > 1 # weirdness
+      if err # weirdness
         @ltConsole.addContent("ERROR #{err.code}: ", br=true)
         @ltConsole.addContent(line, br=true) for line in stderr.split('\n')
 


### PR DESCRIPTION
changed condition under which errors from calling the viewer are shown such that a missing executable throws an error on the user console
