### PR TITLE
Run Sumatra with -reuse-instance

### DIFF
--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -9,7 +9,7 @@ class Viewer extends LTool
 
   _jumpWindows: (texfile, pdffile, row, col, forward_sync, keep_focus) ->
     sumatra_cmd = atom.config.get("latextools.win32.sumatra")
-    sumatra_args = [] # ["-reuse-instance"]
+    sumatra_args = ["-reuse-instance"]
 
     if forward_sync
       sumatra_args = sumatra_args.concat(["-forward-search", '\"'+texfile+'\"', "#{row}"])


### PR DESCRIPTION
This doesn't appear to be necessary with Sumatra 3.1, but with Sumatra 2.5.2, not setting this flag caused it to open a new window per compilation.