### PR TITLE
Fix \addbibresource{}

### DIFF
--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -114,7 +114,7 @@ class CompletionManager extends LTool
       bibs = bibs.concat(b.split(','))
 
     # Trim and take care of .bib extension
-    bibs = ( if path.extname(b)=='.bib' then path.join(filedir, b.trim()) else path.join(filedir, b.trim() + '.bib') for b in bibs )
+    bibs = ((if path.extname(b) isnt '.bib' then path.join(filedir, b.trim()) + '.bib' else path.join(filedir, b.trim())) for b in bibs)
 
     # Check to see if they exist
     bibs = ( b for b in bibs when is_file(b) )


### PR DESCRIPTION
At least for me using `\addbibresource{}` wasn't properly finding bibliography files, since `\addbibresource{}` requires a `.bib` extension for BibLaTeX to properly find the bibliography.

The line in question compiles to something like this:
```javascript
var b, bibs;

bibs = ((function() {
  var i, len, results;
  if (path.extname(b) === '.bib') {
    return path.join(filedir, b.trim());
  } else {
    results = [];
    for (i = 0, len = bibs.length; i < len; i++) {
      b = bibs[i];
      results.push(path.join(filedir, b.trim() + '.bib'));
    }
    return results;
  }
})());
```

In other words, **if** the file name has an extension '.bib', just return the path to the file as a string, otherwise, build the expected list. (Note, too, that `b` in that first conditional is actually going to be the current value of `raw_bibs`)

This PR fixes that to:
```javascript
var b, bibs;

bibs = (function() {
  var i, len, results;
  results = [];
  for (i = 0, len = bibs.length; i < len; i++) {
    b = bibs[i];
    results.push(path.extname(b) !== '.bib' ? path.join(filedir, b.trim()) + '.bib' : path.join(filedir, b.trim()));
  }
  return results;
})();
```

Which is the intended behaviour.