### PR TITLE
Display a SaveAs dialog if build is run with an unsaved text editor

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -63,20 +63,22 @@ class Builder extends LTool
     return command
 
   build: ->
+    te = atom.workspace.getActiveTextEditor()
+
     @ltConsole.show()
     @ltConsole.clear()
 
     # save on build
     # if unsaved, run saveAs
     unless te.getPath()?
-      atom.workspace.getActivePane().saveItem(te)
-
-    if te.isModified()
-      te.save()
+      atom.workspace.paneForItem(te)?.saveItem(te)
 
     unless te.getPath()?
       alert 'Please save your file before attempting to build'
       return
+
+    if te.isModified()
+      te.save()
 
     fname = get_tex_root(te)
 

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -66,15 +66,17 @@ class Builder extends LTool
     @ltConsole.show()
     @ltConsole.clear()
 
-    te = atom.workspace.getActiveTextEditor()
-    if te == ''
-      @ltConsole.addContent("Focus the text editor before invoking a build")
-      return
-
     # save on build
+    # if unsaved, run saveAs
+    unless te.getPath()?
+      atom.workspace.getActivePane().saveItem(te)
 
     if te.isModified()
       te.save()
+
+    unless te.getPath()?
+      alert 'Please save your file before attempting to build'
+      return
 
     fname = get_tex_root(te)
 
@@ -105,6 +107,10 @@ class Builder extends LTool
       user_program = directives.program
     else
       user_program = atom.config.get("latextools.builderSettings.program")
+
+    # prepare the build console
+    @ltConsole.show()
+    @ltConsole.clear()
 
     # Now prepare path
     # TODO: also env if needed


### PR DESCRIPTION
Title says it all... 

`TextEditor#save()` only works if the buffer already has a file name associated with it. With this change, if you try to build an unsaved, unnamed buffer, it will display the save dialog. Cancelling the save dialog aborts the build (since no file name gets set).