### PR TITLE
Fix for issue #21

### DIFF
--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -19,10 +19,7 @@ class CompletionManager extends LTool
     @sel2_view = new LTSelectList2View
 
 
-  refCiteComplete: (keybinding = false) ->
-
-    te = atom.workspace.getActiveTextEditor()
-
+  refCiteComplete: (te, keybinding = false) ->
     max_length = 100 # max length of ref/cite command, including backslash
     #ref_rx = /\\(?:eq|page|v|V|auto|name|c|C|cpage)?ref\{/
     ref_rx_rev = /^\{fer(?:qe|egap|v|V|otua|eman|c|C|egapc)?/

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -213,6 +213,9 @@ module.exports = Latextools =
       if !( path.extname(te.getPath()) in atom.config.get('latextools.texFileExtensions') )
         return
       @subscriptions.add te.onDidStopChanging =>
+        # it doesn't make sense to trigger completions on an inactive text editor
+        if te isnt atom.workspace.getActiveTextEditor()
+          return
         @completionManager.refCiteComplete(te, keybinding=false) \
         if atom.config.get("latextools.refAutoTrigger") or
           atom.config.get("latextools.citeAutoTrigger")

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -213,8 +213,10 @@ module.exports = Latextools =
       if !( path.extname(te.getPath()) in atom.config.get('latextools.texFileExtensions') )
         return
       @subscriptions.add te.onDidStopChanging =>
-        @completionManager.refCiteComplete(keybinding=false) if atom.config.get("latextools.refAutoTrigger") or
-        atom.config.get("latextools.citeAutoTrigger")
+        @completionManager.refCiteComplete(te, keybinding=false) \
+        if atom.config.get("latextools.refAutoTrigger") or
+          atom.config.get("latextools.citeAutoTrigger")
+
         # add more here?
 
   deactivate: ->


### PR DESCRIPTION
Essentially, here's how I reproduced #21:

* Open a new window with a tex document and a non-editable buffer (**Settings** works nicely)
* Reload the window (**Window: Reload** from the palette)

The underlying issue is that while there is code that attempts to ensure it is only run on tex editors that have a recognised tex extension, when `refCiteComplete()` gets run it loads the active TextEditor which may or may not be the same text editor the event was triggered on.

For most TextEditors, this means we are running unnecessary code which may cause unexpected behaviour, but only with something like the **Settings** view which is a TextEditor but does not support the `getCursorPosition()` function do we get an actual error.

Long story short, this PR passes the observed TextEditor to `refCiteComplete` obviating the above and fixing #21.

In addition, since it appears that `onDidStopChanging` can be triggered on a non-active buffer, I added some guard code to ensure that the completions are only run if the buffer is the active buffer