### PR TITLE
Provide an onlyFor parameter to limit scope of directives returned

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -90,8 +90,8 @@ class Builder extends LTool
 
     # Get options and programs
     directives = parse_tex_directives fname,
-      multiValues = ['option'],
-      keyMaps = {'ts-program': 'program'}
+      multiValues: ['option'],
+      keyMaps: {'ts-program': 'program'}
 
     user_options = atom.config.get("latextools.builderSettings.options")
     user_options = user_options.concat directives.option

--- a/lib/ltutils.coffee
+++ b/lib/ltutils.coffee
@@ -29,7 +29,7 @@ module.exports.get_tex_root = (editor) ->
   else
     root = editor.getPath()
 
-  directives = parse_tex_directives editor
+  directives = parse_tex_directives editor, onlyFor: ['root']
   if directives.root?
     root = path.resolve(path.dirname(root), directives.root)
   return root

--- a/lib/parsers/tex-directive-parser.coffee
+++ b/lib/parsers/tex-directive-parser.coffee
@@ -3,10 +3,40 @@ fs = require 'fs'
 texDirectivePattern = /%\s*!(?:T|t)(?:E|e)(?:X|x)\s+([\w-]+)\s*=\s*(.*?)\s*$/
 latexCommandPattern = /\\[a-zA-Z]+\*?(?:\[[^\]]+\])*\{[^\}]+\}/
 
-module.exports = parse_tex_directives =
-  (editorOrPath, multiValues = [], keyMaps = {}) ->
+###
+Parses a TextEditor or file for any %!TEX directives
 
-    result      = {} # new Object
+returns an an object whose own properties are the directive name
+(lower-cased) and whose value is the value after the = sign.
+
+parameters:
+  editorOrPath    - either a TextEditor or path to a file to parse
+
+optional parameters:
+  multiValues     - a list of directives to allow to have multiple values
+                    if not included in the list only the first encountered
+                    value is retained
+  keyMaps         - an object mapping from a directive name encounted to the
+                    directive name returned. intented to allow directives to
+                    be renamed (e.g. ts-program -> program)
+  onlyFor         - a list of the diretcives we are interested in to minimize
+                    the size of the returned object. if only a single value is
+                    present and no multiValues are specified, this will exit
+                    once a match is found
+###
+module.exports = parse_tex_directives =
+  (editorOrPath, {multiValues, keyMaps, onlyFor} = {}) ->
+    # default values and coerce to correct type if possible
+    multiValues ?= []
+    multiValues = [].concat(multiValues) if typeof multiValues is 'string'
+
+    keyMaps ?= {}
+    keyMaps = {} if typeof keyMaps isnt 'object'
+
+    onlyFor ?= []
+    onlyFor = [].concat(onlyFor) if typeof onlyFor is 'string'
+
+    result = {} # new Object
 
     lines =
       if typeof(editorOrPath) is 'string'
@@ -15,6 +45,16 @@ module.exports = parse_tex_directives =
       else
         editorOrPath.getBuffer().getLines()
 
+    hasOnlyFor =
+      try
+        onlyFor? and onlyFor.length > 0
+      catch
+        # onlyFor is some non-array-like type
+        false
+
+    breakOnFirst = hasOnlyFor and onlyFor.length is 1 and (
+      not multiValues? or onlyFor[0] not in multiValues
+    )
 
     for line in lines
       break if line.match latexCommandPattern
@@ -24,12 +64,18 @@ module.exports = parse_tex_directives =
         if key of keyMaps
           key = keyMaps[key]
 
+        if hasOnlyFor and key not in onlyFor
+          continue
+
         if key in multiValues
           if key of result
             result[key].push match[2]
           else
             result[key] = [match[2]]
         else
-          result[key] = match[2]
+          if key not of result
+            result[key] = match[2]
+
+          break if breakOnFirst
 
     return result


### PR DESCRIPTION
This modifies `parse_tex_directives` to provide an `onlyFor` parameter to limit the returned directives. The main intention is to make searching for a single directive more efficient, since, once found, we can stop reading lines.

As part of this, I've switched to using an implementation that relies on optional parameters passed as an object to the function. It makes things a bit clearer when using `onlyFor` and neither of the other two optional parameters.