### PR TITLE
Make the text in the console selectable

### DIFF
--- a/lib/views/ltconsole-view.coffee
+++ b/lib/views/ltconsole-view.coffee
@@ -49,7 +49,8 @@ class LTConsoleView
 
     # body
     @body = document.createElement 'div'
-    @body.classList.add 'panel-body', 'padded'
+    @body.classList.add 'panel-body', 'padded', 'native-key-bindings'
+    @body.setAttribute 'tabindex', -1
     @element.appendChild @body
     # end body
     # end DOM


### PR DESCRIPTION
Title says it all.

I couldn't figure this out initially, but came across [this](https://discuss.atom.io/t/cant-select-panel-text/15453).