### PR TITLE
Fix #43

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -184,8 +184,13 @@ class Builder extends LTool
               @ltConsole.addContent err_string, level: 'error'
             else
               err_string = "#{err[0]}:#{err[1]}: #{err[2]} [#{err[3]}]"
+              file = switch
+                when err[0]? or err[0] is '[no file]' then null
+                when path.isAbsolute(err[0]) then err[0]
+                else path.join(filedir, err[0])
+
               @ltConsole.addContent err_string,
-                file: if path.isAbsolute(err[0]) then err[0] else path.join(filedir,err[0])
+                file: file
                 line: err[1]
                 level: 'error'
 
@@ -197,8 +202,13 @@ class Builder extends LTool
               @ltConsole.addContent warn_string, level: 'warning'
             else
               warn_string = "#{warn[0]}:#{warn[1]}: #{warn[2]}"
+              file = switch
+                when warn[0]? or warn[0] is '[no file]' then null
+                when path.isAbsolute(warn[0]) then warn[0]
+                else path.join(filedir, warn[0])
+
               @ltConsole.addContent warn_string,
-                file: if path.isAbsolute(warn[0]) then warn[0] else path.join(filedir,warn[0])
+                file: file
                 line: warn[1]
                 level: 'warning'
 

--- a/lib/parsers/parse-tex-log.coffee
+++ b/lib/parsers/parse-tex-log.coffee
@@ -155,7 +155,7 @@ module.exports.parse_tex_log = (data) ->
 
   handle_warning = (l) ->
 
-    if files==[]
+    if files.length is 0
       location = "[no file]"
       parsing.push("PERR [handle_warning no files] " + l)
     else
@@ -315,7 +315,7 @@ module.exports.parse_tex_log = (data) ->
       err_line = err_match[1]
       err_text = err_match[2]
       # err_msg is set from last time
-      if files==[]
+      if files.length is 0
         location = "[no file]"
         parsing.push("PERR [STATE_REPORT_ERROR no files] " + line)
       else
@@ -373,7 +373,7 @@ module.exports.parse_tex_log = (data) ->
     # This will match both tex and pdftex Fatal Error messages
     if line.length>0 && line.indexOf("==> Fatal error occurred,") >= 0
       debug("Fatal error detected")
-      if errors == []
+      if errors.length is 0
         errors.push(["", -1, "TeX STOPPED: fatal errors occurred. Check the TeX log file for details",""])
       continue
 


### PR DESCRIPTION
This is a quick-fix for #43, getting the behaviour working as expected.

The log parsing code wasn't quite working as expected because `[] === []` is false in JS (unlike in Python). This switches to using `[].length == 0`, which should test for the expected condition.

The log in #43 still probably isn't parsed as well as could be, but at least this will eliminate the error.