### PR TITLE
Add support for project file

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -80,7 +80,7 @@ class Builder extends LTool
     if te.isModified()
       te.save()
 
-    fname = get_tex_root(te)
+    fname = get_tex_root(te, @ltProject)
 
     parsed_fname = path.parse(fname)
 

--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -71,7 +71,7 @@ class CompletionManager extends LTool
 
   refComplete: (te) ->
 
-    fname = get_tex_root(te) # pass TextEditor, thanks to ig0777's patch
+    fname = get_tex_root(te, @ltProject) # pass TextEditor, thanks to ig0777's patch
 
     parsed_fname = path.parse(fname)
 
@@ -95,7 +95,7 @@ class CompletionManager extends LTool
 
   citeComplete: (te) ->
 
-    fname = get_tex_root(te)
+    fname = get_tex_root(te, @ltProject)
 
     parsed_fname = path.parse(fname)
 

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -3,6 +3,7 @@ Builder = null
 Viewer = null
 CompletionManager = null
 SnippetManager = null
+LTProject = null
 {Disposable, CompositeDisposable} = require 'atom'
 path = require 'path'
 
@@ -175,9 +176,10 @@ module.exports = Latextools =
     @builder = null
     @completionManager = null
     @snippetManager = null
+    @ltProject = null
 
     # ltConsole is needed by all, so load it
-    @requireIfNeeded ['ltconsole']
+    @requireIfNeeded ['ltconsole', 'ltProject']
 
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
@@ -291,16 +293,19 @@ module.exports = Latextools =
           @ltConsole ?= new LTConsole(@state.ltConsoleState)
         when "viewer"
           Viewer ?= require './viewer'
-          @viewer ?= new Viewer(@ltConsole)
+          @viewer ?= new Viewer(@ltConsole, @ltProject)
         when "builder"
           # do an explicit check here,
           if Builder is null
             Builder = require './builder'
-            @builder = new Builder(@ltConsole)
+            @builder = new Builder(@ltConsole, @ltProject)
             @builder.viewer = @viewer # NOTE: MUST be loaded first!
         when "completion-manager"
           CompletionManager ?= require './completion-manager'
-          @completionManager ?= new CompletionManager(@ltConsole)
+          @completionManager ?= new CompletionManager(@ltConsole, @ltProject)
         when "snippet-manager"
           SnippetManager ?= require './snippet-manager'
-          @snippetManager ?= new SnippetManager(@ltConsole)
+          @snippetManager ?= new SnippetManager(@ltConsole, @ltProject)
+        when 'ltProject'
+          LTProject ?= require './ltproject'
+          @ltProject ?= new LTProject()

--- a/lib/ltproject.coffee
+++ b/lib/ltproject.coffee
@@ -1,0 +1,57 @@
+path = require 'path'
+fs = require 'fs'
+{Directory} = require 'atom'
+
+module.exports =
+
+class LTProject
+  constructor: ->
+    console.log 'Create projct settings'
+
+    @TEXroot = null
+
+    # finding .lt-projet file in project path
+    buffer_path = path.dirname(atom.workspace.getActiveTextEditor().getPath())
+    current_path = buffer_path
+    project_file = null
+
+    # search .lt-projet file in current editor's ancestors' path
+    while project_file is null
+
+      # if the root dir, means do not have a .lt-project settings
+      if current_path == '/'
+        console.log "Can not file .lt-project in all paths of current file"
+        break
+
+      current_dir = new Directory(current_path)
+
+      # check if '.lt-project' exist
+      try
+        fs.accessSync path.normalize("#{current_path}/.lt-project"),fs.F_OK
+        project_file = path.normalize("#{current_path}/.lt-project")
+        console.log "find project config file, its path is :#{project_file}"
+      catch error
+        current_path = path.resolve(current_path, "..")
+
+
+    # if find project
+    if project_file?
+
+      # record project's absolute dir
+      project_dir = path.dirname(project_file)
+
+      # check if project_file is is project's paths
+      # if so, set atom project
+      if project_file not in atom.project.getPaths()
+        atom.project.addPath(project_dir)
+        if buffer_path != project_dir
+          atom.project.removePath(buffer_path)
+
+      project_config = JSON.parse(fs.readFileSync(project_file, encoding='utf-8'))
+
+      # configring "TEXroot"
+      if "TEXroot" in key for key of project_config
+        tex_root = project_config["TEXroot"]
+        if not path.isAbsolute(tex_root)
+          tex_root = path.normalize(project_dir + '/' + tex_root)
+        @TEXroot = tex_root

--- a/lib/ltutils.coffee
+++ b/lib/ltutils.coffee
@@ -32,11 +32,12 @@ module.exports.get_tex_root = (editor, project) ->
 
   directives = parse_tex_directives editor
   if directives.root?
-    root = path.resolve(path.dirname(root), directives.root)
-  return root
+    return path.resolve(path.dirname(root), directives.root)
 
   if project?.TEXroot?
     return project.TEXroot
+
+  return root
 
 
 # Check if a file exists

--- a/lib/ltutils.coffee
+++ b/lib/ltutils.coffee
@@ -13,7 +13,7 @@ module.exports.LTool =
 class LTool
   viewer: null
 
-  constructor: (@ltConsole) ->
+  constructor: (@ltConsole, @ltProject) ->
 
 
 # Utility functions
@@ -23,7 +23,11 @@ class LTool
 # TODO add support for configurable extensions
 
 # In: current tex file; Out: file to be compiled
-module.exports.get_tex_root = (editor) ->
+module.exports.get_tex_root = (editor, project) ->
+
+  if project?.TEXroot?
+    return project.TEXroot
+
   if typeof(editor) is 'string'
     root = editor
   else

--- a/lib/ltutils.coffee
+++ b/lib/ltutils.coffee
@@ -25,9 +25,6 @@ class LTool
 # In: current tex file; Out: file to be compiled
 module.exports.get_tex_root = (editor, project) ->
 
-  if project?.TEXroot?
-    return project.TEXroot
-
   if typeof(editor) is 'string'
     root = editor
   else
@@ -37,6 +34,9 @@ module.exports.get_tex_root = (editor, project) ->
   if directives.root?
     root = path.resolve(path.dirname(root), directives.root)
   return root
+
+  if project?.TEXroot?
+    return project.TEXroot
 
 
 # Check if a file exists

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -100,7 +100,7 @@ class Viewer extends LTool
     # this is the file currently being edited, which is where the user wants to jump to
     current_file = te.getPath()
     # it need not be the master file, so we look for that, too
-    master_file = get_tex_root(te)
+    master_file = get_tex_root(te, @ltProject)
 
     parsed_master = path.parse(master_file)
     parsed_current = path.parse(current_file)


### PR DESCRIPTION
* project file should be a json file with name of `.lt-project` in project's dir
* for now only `TEXroot` configuration is supported by project file
* Implementation is used by a `LTProject` class,  by this method project will load just once by the `activate` action of plugin

Here is an example of `.lt-project`

```json
{
    "TEXroot": "main.tex"
}
```