### PR TITLE
atom.notifications for warnings and errors

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -71,7 +71,9 @@ class Builder extends LTool
       atom.workspace.paneForItem(te)?.saveItem(te)
 
     unless te.getPath()?
-      alert 'Please save your file before attempting to build'
+      atom.notifications.addError(
+        'Please save your file before attempting to build'
+      )
       return
 
     if te.isModified()
@@ -167,8 +169,10 @@ class Builder extends LTool
           log = fs.readFileSync(fulllogfile, 'utf8')
         catch error
           @ltConsole.addContent("Could not read log file!")
-          console.log("Could not read log file #{fulllogfile}")
-          console.log(error)
+          atom.notifications.addError(
+            "Could not read log file #{fulllogfile}",
+            detail: error
+          )
           return
 
 
@@ -214,6 +218,15 @@ class Builder extends LTool
                 file: file
                 line: warn[1]
                 level: 'warning'
+
+        unless errors.length > 0
+          atom.notifications.addSuccess(
+            "Build completed with 0 errors and #{warnings.length} warnings"
+          )
+        else
+          atom.notifications.addError(
+            "Build completed with #{errors.length} errors and #{warnings.length} warnings"
+          )
 
         # Jump to PDF
         @ltConsole.addContent("Jumping to PDF...")

--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -119,7 +119,10 @@ class CompletionManager extends LTool
       b
 
     if bibs.length == 0
-      alert("Could not find bib files. Please check your \\bibliography statements")
+      atom.notifications.addWarning(
+        "Could not find any bib files. " +
+        "Please check your \\bibliography statements"
+      )
       return
 
     # If it's a single string, put it in an array
@@ -133,7 +136,10 @@ class CompletionManager extends LTool
       item_fmt = atom.config.get("latextools.citePanelFormat")
 
       if item_fmt.length != 2
-        alert "Incorrect citePanelFormat specification. Check your preferences!"
+        atom.notifications.addError(
+          "Incorrect citePanelFormat specification. Check your preferences!",
+          detail: "Expected 2 entries but got #{item_fmt.length}"
+        )
         return
 
       # Inelegant but safe

--- a/lib/ltutils.coffee
+++ b/lib/ltutils.coffee
@@ -94,7 +94,7 @@ module.exports.find_in_files = (rootdir, src, rx) ->
         break
 
     if not_found
-      alert("Could not find #{src}")
+      atom.notifications.addWarning "Could not find #{src}"
       return null
 
     # i = 0 # old-style looping
@@ -116,7 +116,8 @@ module.exports.find_in_files = (rootdir, src, rx) ->
   try
     src_content = fs.readFileSync(file_path, 'utf-8')
   catch e
-    alert("Could not read #{file_path}; encoding issues?")
+    atom.notifications.addError "Could not read #{file_path}; encoding issues?",
+      detail: e.toString()
     return null
 
   src_content = src_content.replace(/%.*/g, "")

--- a/lib/parsers/get-bib-completions.coffee
+++ b/lib/parsers/get-bib-completions.coffee
@@ -11,7 +11,8 @@ get_bib_completions = (bibfile) ->
   try
     bib = fs.readFileSync(bibfile, 'utf-8').split('\n')
   catch error
-    alert("cannot read " + bibfile)
+    atom.notifications.addError "cannot read #{bibfile}",
+      detail: error.toString()
     return
 
   keywords = []

--- a/lib/snippet-manager.coffee
+++ b/lib/snippet-manager.coffee
@@ -17,8 +17,10 @@ class SnippetManager extends LTool
   wrapInCommand: ->
 
     # In case we haven't gotten the snippets service yet
-    if !@snippetService
-      alert("Still waiting for the snippets service to activate...")
+    unless @snippetService?
+      atom.notifications.addInfo(
+        "Still waiting for the snippets service to activate..."
+      )
       return
 
     te = atom.workspace.getActiveTextEditor()
@@ -37,8 +39,10 @@ class SnippetManager extends LTool
   wrapInEnvironment: ->
 
     # In case we haven't gotten the snippets service yet
-    if !@snippetService
-      alert("Still waiting for the snippets service to activate...")
+    unless @snippetService?
+      atom.notifications.addInfo(
+        "Still waiting for the snippets service to activate..."
+      )
       return
 
     te = atom.workspace.getActiveTextEditor()
@@ -62,8 +66,10 @@ class SnippetManager extends LTool
 
     max_length = 100 # Maximum length of LaTeX command (should be enough!)
 
-    if !@snippetService
-      alert("Still waiting for the snippets service to activate...")
+    unless @snippetService?
+      atom.notifications.addInfo(
+        "Still waiting for the snippets service to activate..."
+      )
       return
 
     te = atom.workspace.getActiveTextEditor()
@@ -85,8 +91,10 @@ class SnippetManager extends LTool
 
   wrapIn: (cmd) ->
 
-    if !@snippetService
-      alert("Still waiting for the snippets service to activate...")
+    unless @snippetService?
+      atom.notifications.addInfo(
+        "Still waiting for the snippets service to activate..."
+      )
       return
 
     te = atom.workspace.getActiveTextEditor()
@@ -124,7 +132,7 @@ class SnippetManager extends LTool
       stop()
 
     if !found
-      alert("No unmatched \\begin")
+      atom.notifications.addError "Could not find unmatched \\begin"
 
   # Handle dollar-sign matching
   # If there is a $ *after* the cursor, just move past it.

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -37,9 +37,14 @@ class Viewer extends LTool
       pdf_file = master_path_no_ext + '.pdf'
       if not is_file(pdf_file)
         log_file = master_path_no_ext + '.log'
-        @ltConsole.addContent(
+        message =
           "Could not find PDF file #{pdf_file}. If no errors appeared from " +
-          "the build, please check your log file, #{log_file}",
+          "the build, please check your log file, #{log_file}"
+
+        atom.notifications.addError message
+
+        @ltConsole.addContent(
+          message,
           file: log_file,
           level: 'error'
         )
@@ -54,7 +59,9 @@ class Viewer extends LTool
       @ltConsole.addContent("Using viewer #{viewerName}")
 
       unless viewerClass?
-        alert("Could not find viewer #{viewerName}. Please check your config.")
+        atom.notifications.addError(
+          "Could not find viewer #{viewerName}. Please check your config."
+        )
         return if viewerName is 'default'
         viewerClass = @viewerRegistry.get 'default'
         return unless viewerClass?


### PR DESCRIPTION
Replaces Javascript alerts with Atom's built-in [notifications API](https://atom.io/docs/api/latest/NotificationManager).