### PR TITLE
Corrected inconsistencies in snippet definitions

### DIFF
--- a/snippets/latex.cson
+++ b/snippets/latex.cson
@@ -143,7 +143,7 @@
   'longrightarrow':
     'prefix': 'rightarrow'
     'body': 'longrightarrow'
-  'Leftarrow':
+  'Rightarrow':
     'prefix': 'Rar'
     'body': '\\\\Rightarrow'
   'Longrightarrow':
@@ -180,14 +180,8 @@
   'mathbb':
     'prefix': 'bb'
     'body': '\\\\mathbb{$1}$0'
-  'mathit':
-    'prefix': 'it'
-    'body': '\\\\mathit{$1}$0'
-  'mathbf':
-    'prefix': 'bf'
-    'body': '\\\\mathbf{$1}$0'
   'mathrm':
-    'prefix': 'bb'
+    'prefix': 'rm'
     'body': '\\\\mathrm{$1}$0'
   'mathsf':
     'prefix': 'sf'


### PR DESCRIPTION
- incorrect title for _Rightarrow_ definition
- _mathit_ and _mathbf_ defined twice
- prefix _bb_ used for _mathrm_ already used for _mathbb_ -> propose prefix _rm_ for _mathrm_