### PR TITLE
Indicate LaTeX tags and page numbers for references

### DIFF
--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -1,7 +1,7 @@
 {LTool,get_tex_root,find_in_files,is_file} = require './ltutils'
 LTSelectListView = require './ltselectlist-view'
 LTSelectList2View = require './ltselectlist2-view'
-#get_ref_completions = require './get-ref-completions'
+get_ref_completions = require './parsers/get-ref-completions'
 get_bib_completions = require './parsers/get-bib-completions'
 path = require 'path'
 fs = require 'fs'
@@ -73,12 +73,7 @@ class CompletionManager extends LTool
 
     fname = get_tex_root(te) # pass TextEditor, thanks to ig0777's patch
 
-    parsed_fname = path.parse(fname)
-
-    filedir = parsed_fname.dir
-    filebase = parsed_fname.base  # name only includes the name (no dir, no ext)
-
-    labels = find_in_files(filedir, filebase, /\\label\{([^\}]+)\}/g)
+    labels = get_ref_completions(fname)
 
     # TODO add partially specified label to search field
     @sel_view.setItems(labels)

--- a/lib/ltselectlist-view.coffee
+++ b/lib/ltselectlist-view.coffee
@@ -11,13 +11,16 @@ class LTSelectListView extends SelectListView
     @panel.hide()
 
   viewForItem: (item) ->
-    "<li>#{item}</li>"
+    "<li>#{item.id} #{item.tag} page #{item.page}</li>"
+
+  getFilterKey: ->
+    'id'
 
   confirmed: (item) ->
     @selected_item = item
     @restoreFocus()
     @panel.hide()
-    @callback(item)
+    @callback(item.id)
 
   # API unclear: cancel or cancelled?
   cancel: ->

--- a/lib/parsers/get-ref-completions.coffee
+++ b/lib/parsers/get-ref-completions.coffee
@@ -1,0 +1,21 @@
+fs = require 'fs'
+
+module.exports =
+get_ref_completions = (rootfile) ->
+  aux_ext = ".aux"
+  aux_file = rootfile.slice(0, -4) + aux_ext
+
+  try
+    aux = fs.readFileSync(aux_file, 'utf-8')
+  catch error
+    atom.notifications.addError "cannot read #{aux_file}",
+      detail: error.toString()
+    return
+
+  rx = /\\newlabel{([^}]+)}{{([^}]+)}{(\d+)}.*}/g
+
+  labels = []
+  while label = rx.exec aux
+    labels.push {id: label[1], tag: label[2], page: label[3]}
+
+  return labels


### PR DESCRIPTION
References parsing is moved to get-ref-completions.coffee. The new module uses
an .aux file to extract references, which is much faster, then scanning all tex
files. Also, it is possible to extract information about tags and pages.

Drawback? The completions do not work if the tex file is not complied. But this
should not be a big deal, as we use this package to compile tex files anyway.