### PR TITLE
Fixes require if needed to (hopefully) address #65.

### DIFF
--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -305,16 +305,17 @@ module.exports = Latextools =
   # Private: ensure modules are loaded on demand
   requireIfNeeded: (modules) ->
     # ltConsole is needed by all, so load it
-    unless LTConsole?
-      LTConsole = require './ltconsole'
-      @ltConsole = new LTConsole @state.ltConsoleState
+    LTConsole ?= require './ltconsole'
+    @ltConsole ?= new LTConsole @state.ltConsoleState
 
     for m in modules
       console.log("requiring if needed: #{m}")
       switch m
         when "viewer"
-          unless Viewer?
-            ViewerRegistry = require './viewer-registry'
+          ViewerRegistry ?= require './viewer-registry'
+          Viewer ?= require './viewer'
+
+          unless @viewerRegistry?
             @viewerRegistry = new ViewerRegistry
 
             @viewerRegistry.add 'pdf-view',
@@ -331,13 +332,15 @@ module.exports = Latextools =
                 @viewerRegistry.add ['default', 'okular'],
                   require './viewers/okular-viewer'
 
-            Viewer = require './viewer'
-            @viewer = new Viewer @viewerRegistry, @ltConsole
+          @viewer ?= new Viewer @viewerRegistry, @ltConsole
         when "builder"
-          unless Builder?
-            Builder = require './builder'
+          Builder ?= require './builder'
+          unless @builder?
             @builder = new Builder(@ltConsole)
-            @builder.viewer = @viewer # NOTE: MUST be loaded first!
+
+            # ensure viewer is loaded before builder
+            requireIfNeeded ['viewer'] unless @viewer?
+            @builder.viewer = @viewer
         when "completion-manager"
           CompletionManager ?= require './completion-manager'
           @completionManager ?= new CompletionManager(@ltConsole)


### PR DESCRIPTION
I don't completely understand what happened in #65, but it looks like somehow the module global value was set (i.e. the required module was loaded) but the instance specific value never got set. I can't figure out how to reproduce the issue, but this (hopefully) corrects the behaviour, since it ensures that `requireIfNeeded` will check the instance value.