### PR TITLE
Fix name of okular viewer

### DIFF
--- a/lib/viewers/okular-viewer.coffee
+++ b/lib/viewers/okular-viewer.coffee
@@ -1,7 +1,7 @@
 BaseViewer = require './base-viewer'
 
 module.exports =
-class SumatraViewer extends BaseViewer
+class OkularViewer extends BaseViewer
   _getArgs = (opts = {}) ->
     args = ["--unique"]
     args.push "--noraise" if opts?.keepFocus


### PR DESCRIPTION
Fixes a dumb copy-and-paste error. Name of viewer class for Okular changed from SumatraViewer -> OkularViewer. This is purely an aesthetic change.