### PR TITLE
Properly escape `\` in snippet text and use transactions where needed

### DIFF
--- a/lib/snippet-manager.coffee
+++ b/lib/snippet-manager.coffee
@@ -26,15 +26,17 @@ class SnippetManager extends LTool
     te = atom.workspace.getActiveTextEditor()
     range = te.getSelectedBufferRange()
     text = te.getTextInBufferRange(range)
+    text = text.replace("\\", "\\\\")
 
-    te.setTextInBufferRange(range, "")
+    te.transact =>
+      te.setTextInBufferRange(range, "")
 
-    snippet = "\\\\$1cmd\{#{text}\}"
-    # This is a HACK around current snippet limitations
-    # Also note that we cannot trigger jumping to the end with $0
-    cmd_range = [[range.start.row, range.start.column+1], [range.start.row, range.start.column+4]]
-    @snippetService.insertSnippet(snippet)
-    te.setSelectedBufferRange(cmd_range)
+      snippet = "\\\\$1cmd\\{#{text}\\}"
+      # This is a HACK around current snippet limitations
+      # Also note that we cannot trigger jumping to the end with $0
+      cmd_range = [[range.start.row, range.start.column+1], [range.start.row, range.start.column+4]]
+      @snippetService.insertSnippet(snippet)
+      te.setSelectedBufferRange(cmd_range)
 
   wrapInEnvironment: ->
 
@@ -48,17 +50,19 @@ class SnippetManager extends LTool
     te = atom.workspace.getActiveTextEditor()
     range = te.getSelectedBufferRange()
     text = te.getTextInBufferRange(range)
+    text = text.replace("\\", "\\\\")
 
-    te.setTextInBufferRange(range, "")
+    te.transact =>
+      te.setTextInBufferRange(range, "")
 
-    snippet = "\\\\begin\{$1env\}\n#{text}\n\\\\end\{$1env\}"
-    # This is a HACK around current snippet limitations
-    cmd_range_begin = [[range.start.row, range.start.column+7], [range.start.row, range.start.column+10]]
-    nlines = text.split('\n').length
-    cmd_range_end = [[range.start.row+nlines+1, range.start.column+5], [range.start.row+nlines+1, range.start.column+8]]
-    @snippetService.insertSnippet(snippet)
-    te.setSelectedBufferRange(cmd_range_begin)
-    te.addSelectionForBufferRange(cmd_range_end)
+      snippet = "\\\\begin\{$1env\}\n#{text}\n\\\\end\{$1env\}"
+      # This is a HACK around current snippet limitations
+      cmd_range_begin = [[range.start.row, range.start.column+7], [range.start.row, range.start.column+10]]
+      nlines = text.split('\n').length
+      cmd_range_end = [[range.start.row+nlines+1, range.start.column+5], [range.start.row+nlines+1, range.start.column+8]]
+      @snippetService.insertSnippet(snippet)
+      te.setSelectedBufferRange(cmd_range_begin)
+      te.addSelectionForBufferRange(cmd_range_end)
 
 
 
@@ -100,6 +104,7 @@ class SnippetManager extends LTool
     te = atom.workspace.getActiveTextEditor()
     range = te.getSelectedBufferRange()
     text = te.getTextInBufferRange(range)
+    text = text.replace("\\", "\\\\")
 
     # Use snippets to easily remove selection, move cursor at end
     # (but only if there is some text)
@@ -147,6 +152,7 @@ class SnippetManager extends LTool
 
     # First, check if there is a selection, and if so, add $..$ around it
     if text =  te.getSelectedText()
+      text = text.replace("\\", "\\\\")
       range = te.getSelectedBufferRange()
       te.setSelectedBufferRange(range, '')
       @snippetService.insertSnippet("\$#{text}\$")
@@ -181,6 +187,7 @@ class SnippetManager extends LTool
 
     # First, check if there is a selection, and if so, add quotes around it
     if text =  te.getSelectedText()
+      text = text.replace("\\", "\\\\")
       range = te.getSelectedBufferRange()
       te.setSelectedBufferRange(range, '')
       # Use snippet to leave selection on (same as ST)


### PR DESCRIPTION
Fixes #82. Basically, snippet text with commands in it ended up looking like this:

```
\\\\$1cmd\\{\emph{something}\\}
            ^
```

The indicated slash would be eliminated somewhere in snippet processing. I've fixed this for all the functions by replacing `\` with `\\` before its added to a snippet.

Additionally, the calls to `setTextInBufferRange(range, "")` where creating their own undo checkpoint which was undesirable, so that undoing, e.g., wrapInCommand results first in blanking all the text and one would have to undo it again to restore the original text. Now only one undo is required, making the insertion of the snippet look like an atomic operation.