### PR TITLE
Ensure files with double extensions are deleted

### DIFF
--- a/lib/commands/delete-temp-files.coffee
+++ b/lib/commands/delete-temp-files.coffee
@@ -19,17 +19,18 @@ module.exports = (te) ->
   fileHandler = (file) ->
     new Promise (resolve, reject) ->
       filePath = file.getPath()
-      parsedFile = path.parse(filePath)
-      if parsedFile.ext in tempFileExts
-        file.exists().then(
-          fs.unlink filePath, (error) ->
-            if error?
-              reject error
-            else
-              resolve filePath
-        )
-      else
-        resolve filePath
+      for ext in tempFileExts
+        if filePath.endsWith(ext)
+          file.exists().then(
+            fs.unlink filePath, (error) ->
+              if error?
+                reject error
+              else
+                resolve filePath
+          )
+          return
+
+      resolve filePath
 
   folderHandler = (directory) ->
     promises = []


### PR DESCRIPTION
The delete-temp-files command currently doesn't work with double extensions, like `.synctex.gz`. This fixes that.