### PR TITLE
Launch completions from keypress

### DIFF
--- a/keymaps/latextools.cson
+++ b/keymaps/latextools.cson
@@ -12,6 +12,8 @@
   '`' : 'latextools:backquote'
   '\'': 'latextools:quote'
   '"' : 'latextools:double-quote'
+  '{' : 'latextools:ref-cite-keypress'
+  ',' : 'latextools:ref-cite-keypress'
 
 "body:not([class~='platform-darwin']) atom-text-editor[data-grammar~='latex']":
   'ctrl-l ctrl-l': 'editor:select-line'

--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -32,7 +32,7 @@ class CompletionManager extends LTool
       cite_rx_rev = /^(?:,[^{},]*)*\{(?:\].*?\[){0,2}([a-zX*]*?)etic\\/
 
     current_point = te.getCursorBufferPosition()
-    initial_point = [current_point.row, Math.max(0,current_point.column - max_length)]
+    initial_point = [current_point.row, Math.max(0, current_point.column - max_length)]
     range = [initial_point, current_point]
     line = te.getTextInBufferRange(range)
 
@@ -44,14 +44,19 @@ class CompletionManager extends LTool
     # TODO: pass initial match to select list
 
     if (keybinding or atom.config.get("latextools.refAutoTrigger")) and
-    m = ref_rx_rev.exec(line)
+        m = ref_rx_rev.exec(line)
       console.log("found match")
       @refComplete(te)
+      return true
     else if (keybinding or atom.config.get("latextools.citeAutoTrigger")) and
-    m = cite_rx_rev.exec(line)
+        m = cite_rx.exec(line)
       console.log("found match")
       console.log(m)
       @citeComplete(te)
+      return true
+    else
+      return false
+
 
     # got_ref = false
     # te.backwardsScanInBufferRange ref_rx, range, ({match, stop}) =>

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -224,6 +224,15 @@ module.exports = Latextools =
       # is run on
       te = `this.getModel()`
       @completionManager.refCiteComplete(te, keybinding=true)
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:ref-cite-keypress': (e) =>
+      e.abortKeyBinding()
+      @requireIfNeeded ['completion-manager', 'snippet-manager']
+      # drop to JS to call this.getModel() which is the TextEditor the command
+      # is run on
+      te = `this.getModel()`
+      setTimeout (=>
+        @completionManager.refCiteComplete(te)
+      ), 50
     @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:delete-temp-files': =>
       deleteTempFiles ?= require './commands/delete-temp-files'
       # drop to JS to call this.getModel() which is the TextEditor the command
@@ -272,23 +281,6 @@ module.exports = Latextools =
     @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:double-quote': =>
       @requireIfNeeded ['snippet-manager']
       @snippetManager.quotes('``', '\'\'', '"')
-
-
-    # Autotriggered functionality
-    # add autocomplete to every text editor that has a tex file
-    atom.workspace.observeTextEditors (te) =>
-      if !( path.extname(te.getPath()) in atom.config.get('latextools.texFileExtensions') )
-        return
-      @subscriptions.add te.onDidStopChanging =>
-        # it doesn't make sense to trigger completions on an inactive text editor
-        if te isnt atom.workspace.getActiveTextEditor()
-          return
-        @requireIfNeeded ['completion-manager', 'snippet-manager']
-        @completionManager.refCiteComplete(te, keybinding=false) \
-        if atom.config.get("latextools.refAutoTrigger") or
-          atom.config.get("latextools.citeAutoTrigger")
-
-        # add more here?
 
   deactivate: ->
     @subscriptions.dispose()


### PR DESCRIPTION
This is a proposal for how to get the cite / ref autocompletions a bit more responsive: it simply makes them respond to a particular key press, using the keymap.

The keymap could be a bit challenging since we'd then be responsible for actually inserting the appropriate text / snippet, but Atom provides a way around this by allowing us to call `abortKeyBinding()`, which simply tells Atom to continue processing the key binding as if we hadn't created a key map at all. We can then continue processing, i.e., checking if we should bring up the pop-up and displaying it.

I've moved the check for whether we should display the pop-up into a `setTimeout` call. I'm not sure whether or not this is necessary, but I figured it would be a good idea to allow Atom some time (50ms) to process the keypress. This works well for me on both a relatively quick computer and a relatively slow one, but it would probably be good to have it tested on other configurations. (In particular, I don't have any other packages that attempt to use the `{` or `,` keys for anything)

This pretty obviously solves the "overaggressive" problem, since the autocompletion is only triggered for specific keys (by default, `{` or `,`) and it could continue to accommodate a prefix using the `C-l, x` binding, but I'm not sure what other uses I might've missed.