### PR TITLE
Add support for Evince

### DIFF
--- a/lib/support/evince_backward_search
+++ b/lib/support/evince_backward_search
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2010 Jose Aliste <jose.aliste@gmail.com>
+#               2011 Benjamin Kellermann <Benjamin.Kellermann@tu-dresden.de>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public Licence as published by the Free Software
+# Foundation; either version 2 of the Licence, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public Licence for more
+# details.
+#
+# You should have received a copy of the GNU General Public Licence along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+# Incorporates fixes from http://ubuntuforums.org/showthread.php?t=1716268
+from __future__ import print_function
+
+import dbus
+import subprocess
+import time
+import sys
+import traceback
+
+if sys.version_info < (3,):
+    from urllib import unquote as urllib_unquote
+    from urllib import quote
+
+    def unquote(s):
+        # This is to deal with source files with non-ascii names
+        # We get url-quoted UTF-8 from dbus; convert to url-quoted ascii
+        # and then unquote. If you don't first convert ot ascii, it fails.
+        # It's a bit magical, but it seems to work
+        return urllib_unquote(s.encode('ascii'))
+else:
+    from urllib.parse import unquote
+    from urllib.parse import quote
+
+RUNNING, CLOSED = range(2)
+
+EV_DAEMON_PATH = "/org/gnome/evince/Daemon"
+EV_DAEMON_NAME = "org.gnome.evince.Daemon"
+EV_DAEMON_IFACE = "org.gnome.evince.Daemon"
+
+EVINCE_PATH = "/org/gnome/evince/Evince"
+EVINCE_IFACE = "org.gnome.evince.Application"
+
+EV_WINDOW_IFACE = "org.gnome.evince.Window"
+
+
+class EvinceWindowProxy:
+
+    """A DBus proxy for an Evince Window."""
+    daemon = None
+    bus = None
+
+    def __init__(self, uri, editor, spawn=False, logger=None):
+        self._log = logger
+        self.uri = uri
+        self.editor = editor
+        self.status = CLOSED
+        self.source_handler = None
+        self.dbus_name = ''
+        self._handler = None
+
+        try:
+            if EvinceWindowProxy.bus is None:
+                EvinceWindowProxy.bus = dbus.SessionBus()
+
+            if EvinceWindowProxy.daemon is None:
+                EvinceWindowProxy.daemon = \
+                    EvinceWindowProxy.bus.get_object(
+                        EV_DAEMON_NAME,
+                        EV_DAEMON_PATH,
+                        follow_name_owner_changes=True
+                    )
+
+            EvinceWindowProxy.bus.add_signal_receiver(
+                self._on_doc_loaded,
+                signal_name='DocumentLoaded',
+                dbus_interface=EV_WINDOW_IFACE,
+                sender_keyword='sender'
+            )
+            self._get_dbus_name(False)
+        except dbus.DBusException:
+            traceback.print_exc()
+            if self._log:
+                self._log.debug("Could not connect to the Evince Daemon")
+
+    def _on_doc_loaded(self, uri, **keyargs):
+        if (
+            unquote(uri) == self.uri and
+            self._handler is None
+        ):
+            self.handle_find_document_reply(keyargs['sender'])
+
+    def _get_dbus_name(self, spawn):
+        EvinceWindowProxy.daemon.FindDocument(
+            self.uri,
+            spawn,
+            reply_handler=self.handle_find_document_reply,
+            error_handler=self.handle_find_document_error,
+            dbus_interface=EV_DAEMON_IFACE
+        )
+
+    def handle_find_document_error(self, error):
+        if self._log:
+            self._log.debug("FindDocument DBus call has failed")
+
+    def handle_find_document_reply(self, evince_name):
+        if self._handler is not None:
+            handler = self._handler
+        else:
+            handler = self.handle_get_window_list_reply
+        if evince_name != '':
+            self.dbus_name = evince_name
+            self.status = RUNNING
+            self.evince = EvinceWindowProxy.bus.get_object(
+                self.dbus_name, EVINCE_PATH
+            )
+
+            self.evince.GetWindowList(
+                dbus_interface=EVINCE_IFACE,
+                reply_handler=handler,
+                error_handler=self.handle_get_window_list_error
+            )
+
+    def handle_get_window_list_error(self, e):
+        if self._log:
+            self._log.debug("GetWindowList DBus call has failed")
+
+    def handle_get_window_list_reply(self, window_list):
+        if len(window_list) > 0:
+            window_obj = EvinceWindowProxy.bus.get_object(
+                self.dbus_name, window_list[0]
+            )
+            self.window = dbus.Interface(window_obj, EV_WINDOW_IFACE)
+            self.window.connect_to_signal("SyncSource", self.on_sync_source)
+        else:
+            # This should never happen.
+            if self._log:
+                self._log.debug("GetWindowList returned empty list")
+
+    def on_sync_source(self, input_file, source_link, _):
+        print(input_file + ":" + str(source_link[0]))
+        input_file = unquote(input_file)
+        cmd = self.editor.replace('%f', input_file)
+        cmd = cmd.replace('%l', str(source_link[0]))
+        print(cmd)
+        subprocess.call(cmd, shell=True)
+        if self.source_handler is not None:
+            self.source_handler(input_file, source_link, time)
+
+
+# This file offers backward search in any editor.
+#  evince_dbus pdf_file line_source input_file
+if __name__ == '__main__':
+    import dbus.mainloop.glib
+    import sys
+    import os
+
+    def print_usage():
+        print("""Usage:
+  evince_backward_search pdf_file "editorcmd %f %l"'
+    %f ... TeX-file to load
+    %l ... line to jump to
+E.g.:
+  evince_backward_search somepdf.pdf "gvim --servername somepdf --remote-silent '+%l<Enter>' %f"
+  evince_backward_search somepdf.pdf "emacsclient -a emacs --no-wait +%l %f"
+  evince_backward_search somepdf.pdf "scite %f '-goto:%l'"
+  evince_backward_search somepdf.pdf "lyxclient -g %f %l"
+  evince_backward_search somepdf.pdf "kate --use --line %l"
+  evince_backward_search somepdf.pdf "kile --line %l" """)
+        sys.exit(1)
+
+    if len(sys.argv) != 3:
+        print_usage()
+
+    pdf_file = os.path.abspath(sys.argv[1])
+
+    if not os.path.isfile(pdf_file):
+        print_usage()
+
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    EvinceWindowProxy(
+        # The PDF file name MUST be URI-encoded
+        # RFC 1738: unreserved = alpha | digit | safe | extra
+        #           safe       = "$" | "-" | "_" | "." | "+"
+        #           extra      = "!" | "*" | "'" | "(" | ")" | ","
+        'file://' + quote(pdf_file, "/$+!*'(),"),
+        sys.argv[2],
+        True
+    )
+
+    try:
+        import gobject
+        loop = gobject.MainLoop()
+    except ImportError:
+        from gi.repository import GLib
+        loop = GLib.MainLoop()
+    loop.run()
+# ex:ts=4:et:

--- a/lib/support/evince_backward_search
+++ b/lib/support/evince_backward_search
@@ -62,6 +62,7 @@ class EvinceWindowProxy:
     def __init__(self, uri, editor, spawn=False, logger=None):
         self._log = logger
         self.uri = uri
+        self.uri_unquoted = unquote(uri)
         self.editor = editor
         self.status = CLOSED
         self.source_handler = None
@@ -94,7 +95,7 @@ class EvinceWindowProxy:
 
     def _on_doc_loaded(self, uri, **keyargs):
         if (
-            unquote(uri) == self.uri and
+            unquote(uri) == self.uri_unquoted and
             self._handler is None
         ):
             self.handle_find_document_reply(keyargs['sender'])
@@ -192,7 +193,7 @@ E.g.:
         # RFC 1738: unreserved = alpha | digit | safe | extra
         #           safe       = "$" | "-" | "_" | "." | "+"
         #           extra      = "!" | "*" | "'" | "(" | ")" | ","
-        'file://' + quote(pdf_file, "/$+!*'(),"),
+        'file://' + quote(pdf_file, "/$+!*'(),@=~"),
         sys.argv[2],
         True
     )

--- a/lib/support/evince_forward_search
+++ b/lib/support/evince_forward_search
@@ -25,7 +25,6 @@ import dbus
 import sys
 import os
 import traceback
-import time
 
 if sys.version_info < (3,):
     from urllib import quote
@@ -58,17 +57,15 @@ if __name__ == '__main__':
             # RFC 1738: unreserved = alpha | digit | safe | extra
             #           safe       = "$" | "-" | "_" | "." | "+"
             #           extra      = "!" | "*" | "'" | "(" | ")" | ","
-            'file://' + quote(pdf_file, "/$+!*'(),"),
+            'file://' + quote(pdf_file, "/$+!*'(),@=~"),
             True,
             dbus_interface="org.gnome.evince.Daemon"
         )
         window = bus.get_object(dbus_name, '/org/gnome/evince/Window/0')
-        # Added int(time.time()) per
-        # https://www.benwhale.com/blog/evince-synctex-support-broke-for-me-today/
         window.SyncView(
             tex_file,
             (line_number, 1),
-            int(time.time()),
+            0,  # GDK_CURRENT_TIME constant
             dbus_interface="org.gnome.evince.Window"
         )
     except dbus.DBusException:

--- a/lib/support/evince_forward_search
+++ b/lib/support/evince_forward_search
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2010 Jose Aliste <jose.aliste@gmail.com>
+#               2011 Benjamin Kellermann <Benjamin.Kellermann@tu-dresden.de>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public Licence as published by the Free Software
+# Foundation; either version 2 of the Licence, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public Licence for more
+# details.
+#
+# You should have received a copy of the GNU General Public Licence along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+# This file offers forward search for evince.
+from __future__ import print_function
+
+import dbus
+import sys
+import os
+import traceback
+import time
+
+if sys.version_info < (3,):
+    from urllib import quote
+else:
+    from urllib.parse import quote
+
+if __name__ == '__main__':
+    def print_usage():
+        print('Usage: evince_forward_search pdf_file line_number tex_file')
+        sys.exit(1)
+
+    if len(sys.argv) != 4:
+        print_usage()
+    try:
+        line_number = int(sys.argv[2])
+    except ValueError:
+        print_usage()
+
+    pdf_file = os.path.abspath(sys.argv[1])
+    line = int(sys.argv[2])
+    tex_file = os.path.abspath(sys.argv[3])
+
+    try:
+        bus = dbus.SessionBus()
+        daemon = bus.get_object(
+            'org.gnome.evince.Daemon', '/org/gnome/evince/Daemon'
+        )
+        dbus_name = daemon.FindDocument(
+            # The PDF file name MUST be URI-encoded
+            # RFC 1738: unreserved = alpha | digit | safe | extra
+            #           safe       = "$" | "-" | "_" | "." | "+"
+            #           extra      = "!" | "*" | "'" | "(" | ")" | ","
+            'file://' + quote(pdf_file, "/$+!*'(),"),
+            True,
+            dbus_interface="org.gnome.evince.Daemon"
+        )
+        window = bus.get_object(dbus_name, '/org/gnome/evince/Window/0')
+        # Added int(time.time()) per
+        # https://www.benwhale.com/blog/evince-synctex-support-broke-for-me-today/
+        window.SyncView(
+            tex_file,
+            (line_number, 1),
+            int(time.time()),
+            dbus_interface="org.gnome.evince.Window"
+        )
+    except dbus.DBusException:
+        traceback.print_exc()

--- a/lib/support/evince_sync
+++ b/lib/support/evince_sync
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+PYTHON="$1"
+ATOM="$2"
+
+# We need to remove the stupid "file://" that Evince puts in front of the file name
+# Notice the wild quoting: we need to interpolate $ATOM
+# In the end, EDITORCMD should be of the form:
+#
+# f=%f; atom "${f#file://}:%l"
+#
+# where atom is the name of the atom binary
+EDITORCMD="f=\"%f\"; $ATOM \"\${f#file://}:%l\""
+
+PDFFILE="$3"
+
+if [ -f "$PDFFILE" ];then
+	# danke an Feuerfieber
+	# http://forum.ubuntuusers.de/topic/evince-synctex-vim-emacs-scite-lyx-kile-editor/#post-2841828
+	if [ -f "${PDFFILE%%.pdf}.synctex.gz" ];then
+		# we change the cwd to this directory, so this should work
+		# also note that we stick in 'python' because the script file need not be executable
+		$PYTHON evince_backward_search "$PDFFILE" "$EDITORCMD"&
+		BACKWARD_SEARCH_PID=$!
+		echo $BACKWARD_SEARCH_PID
+	fi
+fi
+
+/usr/bin/evince "$3"
+
+if [ "$BACKWARD_SEARCH_PID" ];then
+	echo "Killing $BACKWARD_SEARCH_PID"
+	kill $BACKWARD_SEARCH_PID
+fi

--- a/lib/viewer-registry.coffee
+++ b/lib/viewer-registry.coffee
@@ -17,3 +17,12 @@ class ViewerRegistry
   get: (name) ->
     return @viewers[name] if name of @viewers
     undefined
+
+  updateConfigSchema: ->
+    viewers = Object.keys(@viewers)
+      .filter((n) -> n isnt 'default')
+      .sort()
+
+    viewers.unshift('default')
+
+    atom.config.getSchema('latextools.viewer').enum = viewers

--- a/lib/viewers/base-viewer.coffee
+++ b/lib/viewers/base-viewer.coffee
@@ -23,6 +23,11 @@ class BaseViewer
     else
       execFile command[0], [], callback
 
+  doAfterPause: (func) ->
+    setTimeout func,
+      atom.config.get("latextools.#{process.platform}.syncWait") * 1000 or
+      1000
+
   handleExec: (err, stdout, stderr) =>
     if err
       @ltConsole.addContent("ERROR #{err.code}")

--- a/lib/viewers/evince-viewer.coffee
+++ b/lib/viewers/evince-viewer.coffee
@@ -1,0 +1,100 @@
+BaseViewer = require './base-viewer'
+{execFile, execFileSync} = require 'child_process'
+path = require 'path'
+{quote} = require '../ltutils'
+
+module.exports =
+class EvinceViewer extends BaseViewer
+  getAtomExecutable: ->
+    unless @_atom?
+      @_atom = atom.config.get("latextools.#{process.platform}.atomExecutable")
+      @_atom = 'atom' if @_atom? or @_atom is ''
+    Promise.resolve(@_atom)
+
+  checkPythons: (pythons) ->
+    new Promise (resolve, reject) ->
+      done = false
+      for python in pythons
+        unless done
+          try
+            execFileSync python, ['-c', 'import dbus']
+            resolve(python)
+            done = true
+          catch
+      reject()
+
+  getPython: ->
+    if @_python? and @_python isnt ''
+      Promise.resolve(@_python)
+    else
+      python = atom.config.get("latextools.#{process.platform}.python")
+      if python? and python isnt ''
+        @_python = python
+        Promise.resolve(python)
+      else
+        @checkPythons(['python', 'python3', 'python2']).then(
+          (python) => @_python = python,
+          ->
+            atom.notifications.addError(
+              '''Cannot find a valid Python interpreter.
+              Please ensure your `python` setting is correct in your Latextools settings.
+              '''
+            )
+
+            # try to exit out if we can't find python
+            throw
+              name: "Python not found error"
+              description: "A valid Python interpreter could not be found"
+        )
+
+  evinceIsRunning: (pdfFile) ->
+    new Promise (resolve, reject) ->
+      execFile 'ps', ['xw'], (err, stdout, stderr) ->
+        if err? or stdout.indexOf("evince #{pdfFile}") < 0
+          reject()
+        else
+          resolve()
+
+  launchEvince: (pdfFile) ->
+    Promise.all([@getPython(), @getAtomExecutable()]).then ([python, atom]) =>
+      cwd = path.join(
+        window.atom.packages.resolvePackagePath('latextools'),
+        'lib',
+        'support'
+      )
+
+      command = ['/bin/sh', 'evince_sync', python, atom, pdfFile]
+      @ltConsole.addContent "Executing #{quote(command)}"
+      execFile command[0], command[1..], cwd: cwd
+
+  sync: (pdfFile, texFile, line, col, python) ->
+    execFile python, [
+      path.join(
+        window.atom.packages.resolvePackagePath('latextools'),
+        'lib', 'support', 'evince_forward_search'
+      ),
+      pdfFile, "#{line}", texFile
+    ]
+
+  forwardSync: (pdfFile, texFile, line, col, opts = {}) ->
+    @viewFile(pdfFile, opts).then (pause) =>
+      @getPython().then (python) =>
+        if pause
+          @doAfterPause => @sync(pdfFile, texFile, line, col, python)
+        else
+          @sync(pdfFile, texFile, line, col, python)
+
+  viewFile: (pdfFile, opts = {}) ->
+    keepFocus = opts?.keepFocus
+
+    @evinceIsRunning(pdfFile).then(
+      (->
+        if not keepFocus
+          execFile('evince', [pdfFile])
+          true
+        else
+          false),
+      =>
+        @launchEvince(pdfFile)
+        true
+    )

--- a/lib/viewers/evince-viewer.coffee
+++ b/lib/viewers/evince-viewer.coffee
@@ -37,8 +37,7 @@ class EvinceViewer extends BaseViewer
           ->
             atom.notifications.addError(
               '''Cannot find a valid Python interpreter.
-              Please ensure your `python` setting is correct in your Latextools settings.
-              '''
+              Please ensure your `python` setting is correct in your LaTeXTools settings.'''
             )
 
             # try to exit out if we can't find python


### PR DESCRIPTION
As requested in #26. This adds an Evince viewer using the same scripts we use on the Sublime version. This means it requires a python interpreter (2.7 or 3.4+; may work on other versions, I just haven't tested) with the `dbus` bindings installed. If you are using a Gnome-based desktop, you likely already have this.

In addition, the drop-down to choose a viewer should now be dynamically populated, which means that on Linux (well, anything that isn't OS X / Darwin or Windows), `evince` will appear. In addition, the default viewers are exposed as an options (`okular`, `sumatra`, `skim`) and any viewer registered with `Latextools.addViewer` should also appear in the list.
