### PR TITLE
Ensure okular always launched using --unique

### DIFF
--- a/lib/viewers/base-viewer.coffee
+++ b/lib/viewers/base-viewer.coffee
@@ -23,6 +23,11 @@ class BaseViewer
     else
       execFile command[0], [], callback
 
+  doAfterPause: (func) ->
+    setTimeout func,
+      atom.config.get("latextools.#{process.platform}.syncWait") * 1000 or
+      1000
+
   handleExec: (err, stdout, stderr) =>
     if err
       @ltConsole.addContent("ERROR #{err.code}")

--- a/lib/viewers/okular-viewer.coffee
+++ b/lib/viewers/okular-viewer.coffee
@@ -1,4 +1,5 @@
 BaseViewer = require './base-viewer'
+{execFile} = require 'child_process'
 
 module.exports =
 class OkularViewer extends BaseViewer
@@ -7,14 +8,35 @@ class OkularViewer extends BaseViewer
     args.push "--noraise" if opts?.keepFocus
     args
 
+  okularIsRunning: ->
+    new Promise (resolve, reject) ->
+      execFile 'ps', ['xw'], (err, stdout, stderr) ->
+        unless err?
+          for line in stdout.match /^.*([\n\r]+|$)/gm
+            if line.indexOf("okular") > 0 and line.indexOf("--unique") > 0
+              resolve()
+              break
+
+        reject()
+
+  ensureOkular: ->
+    @okularIsRunning().catch ->
+      new Promise (resolve, reject) ->
+        execFile 'okular', ['--unique'], (err, stdout, stderr) ->
+          resolve()
+
   forwardSync: (pdfFile, texFile, line, col, opts = {}) ->
-    args = _getArgs opts
-    args.push "#{pdfFile}#src:#{line}#{texFile}"
-    args.unshift 'okular'
-    @runViewer args
+    @ensureOkular().then =>
+      @doAfterPause =>
+        args = _getArgs opts
+        args.push "#{pdfFile}#src:#{line}#{texFile}"
+        args.unshift 'okular'
+        @runViewer args
 
   viewFile: (pdfFile, opts = {}) ->
-    args = _getArgs opts
-    args.push "#{pdfFile}"
-    args.unshift 'okular'
-    @runViewer args
+    @ensureOkular().then =>
+      @doAfterPause =>
+        args = _getArgs opts
+        args.push "#{pdfFile}"
+        args.unshift 'okular'
+        @runViewer args


### PR DESCRIPTION
See [SublimeText/LaTeXTools#730](https://github.com/SublimeText/LaTeXTools/issues/730#issuecomment-219309706). Essentially, this ensures that we always open the document in the Okular unique session, even if Okular has been previously opened.