### PR TITLE
Use kpsewhich to search for bibliography files

### DIFF
--- a/lib/commands/kpsewhich.coffee
+++ b/lib/commands/kpsewhich.coffee
@@ -1,0 +1,15 @@
+{execFileSync} = require 'child_process'
+path = require 'path'
+
+module.exports = (fileName, fileFormat) ->
+  args = [fileName]
+  args.unshift "-format=#{fileFormat}" if fileFormat?
+
+  texpath = atom.config.get "latextools.#{process.platform}.texpath"
+  env = process.env
+  env.PATH = env.PATH + path.delimiter + texpath if texpath
+
+  try
+    "#{execFileSync 'kpsewhich', args, env: env}".trim()
+  catch e
+    fileName

--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -3,6 +3,7 @@ LTSimpleSelectList = require './views/ltsimple-select-list-view'
 LTTwoLineSelectList = require './views/lttwo-line-select-list-view'
 #get_ref_completions = require './get-ref-completions'
 get_bib_completions = require './parsers/get-bib-completions'
+kpsewhich = require './commands/kpsewhich'
 path = require 'path'
 fs = require 'fs'
 
@@ -184,13 +185,18 @@ class CompletionManager extends LTool
 
     fname = get_tex_root(te)
 
-    parsed_fname = path.parse(fname)
-
-    filedir = parsed_fname.dir
-    filebase = parsed_fname.base  # name only includes the name (no dir, no ext)
-
     bib_rx = /\\(?:bibliography|nobibliography|addbibresource)\{([^\}]+)\}/g
-    raw_bibs = find_in_files(filedir, filebase, bib_rx)
+
+    try
+      parsed_fname = path.parse(fname)
+      filedir = parsed_fname.dir
+      #  name only includes the name (no dir, no ext)
+      filebase = parsed_fname.base
+      raw_bibs = find_in_files(filedir, filebase, bib_rx)
+    catch
+      # no file name, so simply parse the active buffer
+      raw_bibs = []
+      te.scan bib_rx, (match) -> raw_bibs.push match.match[1]
 
     # Split multiple bib files
     bibs = []
@@ -199,10 +205,23 @@ class CompletionManager extends LTool
 
     # Trim and take care of .bib extension
     bibs = for b in bibs
-      b = path.resolve(filedir, b) unless path.isAbsolute(b)
-      b = b.trim() + '.bib' unless path.extname(b) is '.bib'
+      base = b.trim() + '.bib' unless path.extname(b) is '.bib'
+      b = if path.isAbsolute(base)
+        base
+      else
+        if filedir?
+          path.resolve(filedir, base)
+        else
+          null
+
       # Check to see if the file exists
-      continue unless is_file(b)
+      unless is_file(b)
+        # i.e. b is an absolute path
+        continue if b is base
+
+        # fallback to using kpsewhich
+        b = kpsewhich(base)
+        continue unless is_file(b)
       b
 
     if bibs.length == 0


### PR DESCRIPTION
This PR uses `kpsewhich` to find bibliography files in the `TEXMF` tree (provided they'd otherwise be findable via kpsewhich... We probably have some work to do to support `TEXINPUTS`). In addition, I've somewhat modified the bib search code so that if its run on an unsaved text editor, it will at least scan the current buffer before failing.

Addresses #92.