### PR TITLE
Add a command to change the surrounding environment

### DIFF
--- a/keymaps/latextools.cson
+++ b/keymaps/latextools.cson
@@ -50,6 +50,7 @@
   'cmd-l n': 'latextools:insert-environment'
   'cmd-l cmd-c': 'latextools:wrap-in-command'
   'cmd-l cmd-n': 'latextools:wrap-in-environment'
+  'cmd-l cmd-shift-n': 'latextools:change-environment'
   'cmd-l cmd-e': 'latextools:wrap-in-emph'
   'cmd-l cmd-b': 'latextools:wrap-in-bold'
   'cmd-l cmd-u': 'latextools:wrap-in-underline'

--- a/keymaps/latextools.cson
+++ b/keymaps/latextools.cson
@@ -29,6 +29,7 @@
   'ctrl-l n': 'latextools:insert-environment'
   'ctrl-l ctrl-c': 'latextools:wrap-in-command'
   'ctrl-l ctrl-n': 'latextools:wrap-in-environment'
+  'ctrl-l ctrl-shift-n': 'latextools:change-environment'
   'ctrl-l ctrl-e': 'latextools:wrap-in-emph'
   'ctrl-l ctrl-b': 'latextools:wrap-in-bold'
   'ctrl-l ctrl-u': 'latextools:wrap-in-underline'

--- a/lib/commands/change-environment.coffee
+++ b/lib/commands/change-environment.coffee
@@ -54,7 +54,6 @@ module.exports = () ->
           # if the are opening environments, pop them from the stack
           envObj.stack.pop()
         else
-          envObj.end = range
           if envObj.beginName != name
             atom.notifications.addWarning(
               "Environment '#{envObj.beginName}' and '#{name}' are not matching."
@@ -62,6 +61,7 @@ module.exports = () ->
             delete envObj.begin
             envObj.end = [envObj.cursor, envObj.cursor]
           else
+            envObj.end = range
 
     # if every env has an end, we are done
     if (cursorEnv.every (x) -> x.end?)

--- a/lib/commands/change-environment.coffee
+++ b/lib/commands/change-environment.coffee
@@ -73,3 +73,4 @@ module.exports = () ->
   sels = sels.filter (x) -> x
   # set the selections in the
   te.setSelectedBufferRanges(sels)
+  te.scrollToBufferPosition(sels[0][0]) if sels.length

--- a/lib/commands/change-environment.coffee
+++ b/lib/commands/change-environment.coffee
@@ -21,54 +21,54 @@ module.exports = () ->
 
     cursorEnv.forEach (envObj) ->
       # if the environment is still before the cursor
-      if envObj["cursor"].isGreaterThan(envBorder)
+      if envObj.cursor.isGreaterThan(envBorder)
         if isBegin
           # push opening environments on the stack
-          envObj["stack"].push([name, range])
+          envObj.stack.push([name, range])
         else
           # pop closing environments from the stack
-          envObj["stack"].pop()
+          envObj.stack.pop()
       # if the environment is behind the cursor, but the end has not been found
-      else if !envObj["end"]?
+      else if !envObj.end?
         # if we are the first time behind the cursor
         # pop and insert the last environment name
-        if !envObj["begin"]?
+        if !envObj.begin?
           try
-            [popName, popRange] = envObj["stack"].pop()
+            [popName, popRange] = envObj.stack.pop()
           catch
             # if the stack was empty keep the cursor
-            envObj["end"] = [envObj["cursor"], envObj["cursor"]]
+            envObj.end = [envObj.cursor, envObj.cursor]
             atom.notifications.addWarning(
               "Cannot detect the surrounding environment for one cursor."
             )
             return
-          envObj["begin"] = popRange
-          envObj["beginName"] = popName
+          envObj.begin = popRange
+          envObj.beginName = popName
           # reset the environment stack
-          envObj["stack"] = []
+          envObj.stack = []
 
         if isBegin
           # push the opening environments on the stack
-          envObj["stack"].push(name)
-        else if envObj["stack"].length
+          envObj.stack.push(name)
+        else if envObj.stack.length
           # if the are opening environments, pop them from the stack
-          envObj["stack"].pop()
+          envObj.stack.pop()
         else
-          envObj["end"] = range
-          if envObj["beginName"] != name
+          envObj.end = range
+          if envObj.beginName != name
             atom.notifications.addWarning(
               "Environment '#{envObj.beginName}' and '#{name}' are not matching."
             )
-            delete envObj["begin"]
-            envObj["end"] = [envObj["cursor"], envObj["cursor"]]
+            delete envObj.begin
+            envObj.end = [envObj.cursor, envObj.cursor]
           else
 
     # if every env has an end, we are done
-    if (cursorEnv.every (x) -> x["end"]?)
+    if (cursorEnv.every (x) -> x.end?)
       matchObj.stop()
   )
   # retrieve the selections
-  sels = [].concat.apply([], ([x["begin"], x["end"]] for x in cursorEnv))
+  sels = [].concat.apply([], ([x.begin, x.end] for x in cursorEnv))
   # filter undefined/invalid cursors (missing ends...)
   sels = sels.filter (x) -> x
   # set the selections in the

--- a/lib/commands/change-environment.coffee
+++ b/lib/commands/change-environment.coffee
@@ -1,0 +1,75 @@
+module.exports = () ->
+  # ignore environments in these scopes
+  ignoredScopes = ["comment", "markup.raw.verbatim"]
+  te = atom.workspace.getActiveTextEditor()
+  cursorEnv = ({cursor: cursor, stack: []} for cursor in te.getCursorBufferPositions())
+  envRegex = /\\(begin|end)(?:\[[^\]]*\])?\{([^\}]*)\}/g
+  te.scan(envRegex, (matchObj) ->
+    match = matchObj.match
+    name = match[2]
+    isBegin = match[1] == "begin"
+    # get the outer point of the environment
+    envBorder = if isBegin then matchObj.range.start else matchObj.range.end
+    # ignore comments
+    descriptor = te.scopeDescriptorForBufferPosition(envBorder)
+    if (descriptor.getScopesArray().some (d) -> (ignoredScopes.some (s) -> d.startsWith(s)))
+      return
+    # retrieve information about the match object
+    endPoint = matchObj.range.end
+    column = endPoint.column - 1
+    range = [[endPoint.row, column - name.length], [endPoint.row, column]]
+
+    cursorEnv.forEach (envObj) ->
+      # if the environment is still before the cursor
+      if envObj["cursor"].isGreaterThan(envBorder)
+        if isBegin
+          # push opening environments on the stack
+          envObj["stack"].push([name, range])
+        else
+          # pop closing environments from the stack
+          envObj["stack"].pop()
+      # if the environment is behind the cursor, but the end has not been found
+      else if !envObj["end"]?
+        # if we are the first time behind the cursor
+        # pop and insert the last environment name
+        if !envObj["begin"]?
+          try
+            [popName, popRange] = envObj["stack"].pop()
+          catch
+            # if the stack was empty keep the cursor
+            envObj["end"] = [envObj["cursor"], envObj["cursor"]]
+            atom.notifications.addWarning(
+              "Cannot detect the surrounding environment for one cursor."
+            )
+            return
+          envObj["begin"] = popRange
+          envObj["beginName"] = popName
+          # reset the environment stack
+          envObj["stack"] = []
+
+        if isBegin
+          # push the opening environments on the stack
+          envObj["stack"].push(name)
+        else if envObj["stack"].length
+          # if the are opening environments, pop them from the stack
+          envObj["stack"].pop()
+        else
+          envObj["end"] = range
+          if envObj["beginName"] != name
+            atom.notifications.addWarning(
+              "Environment '#{envObj.beginName}' and '#{name}' are not matching."
+            )
+            delete envObj["begin"]
+            envObj["end"] = [envObj["cursor"], envObj["cursor"]]
+          else
+
+    # if every env has an end, we are done
+    if (cursorEnv.every (x) -> x["end"]?)
+      matchObj.stop()
+  )
+  # retrieve the selections
+  sels = [].concat.apply([], ([x["begin"], x["end"]] for x in cursorEnv))
+  # filter undefined/invalid cursors (missing ends...)
+  sels = sels.filter (x) -> x
+  # set the selections in the
+  te.setSelectedBufferRanges(sels)

--- a/lib/latextools.coffee
+++ b/lib/latextools.coffee
@@ -245,6 +245,9 @@ module.exports = Latextools =
     @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:wrap-in-command': =>
       @requireIfNeeded ['snippet-manager']
       @snippetManager.wrapInCommand()
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:change-environment': =>
+      changeEnvironment = require './commands/change-environment'
+      changeEnvironment()
     @subscriptions.add atom.commands.add 'atom-text-editor', 'latextools:wrap-in-environment': =>
       @requireIfNeeded ['snippet-manager']
       @snippetManager.wrapInEnvironment()


### PR DESCRIPTION
This resolves https://github.com/msiniscalchi/atom-latextools/issues/102 similar to the ST PR https://github.com/SublimeText/LaTeXTools/pull/585.

This adds the command `C-l, C-S-n` to change the surrounding environment. It supports:
- nested environments
- multiple cursors
- exclude definitions in comments and verbatim (easily expandable scope selector/descriptor list)

demo:

![atom_change_env](https://cloud.githubusercontent.com/assets/12573621/15481059/f50b585c-2128-11e6-87fd-85cd04dca0b6.gif)
