### PR TITLE
Use an activation hook to delay loading latextools

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
         ">= 0.1.0": "consumeSnippets"
       }
     }
-  }
+  },
+  "activationHooks": ["language-latex:grammar-used"]
 }


### PR DESCRIPTION
Takes advantage of the `activationHook` feature of Atom to ensure the package is only loaded when the `language-latex` grammar has been used. Not a major feature, but hopefully helps out when people use Atom for things other than LaTeX.