### PR TITLE
Add support for project files

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -302,3 +302,36 @@ LaTeXTools' wrapping facility helps you in just these circumstances. All command
 `C-l C-e`, `C-l C-b`, `C-l C-u` and `C-l C-m` should be self-explanatory. `C-l C-c` wraps the selected text in a LaTeX command structure. If the currently selected text is `blah`, you get `\cmd{blah}`, and the letters `cmd` are highlighted. Replace them with whatever you want, then hit Tab: the cursor will move to the end of the command. Finally, `C-l C-n` wraps the selected text in a LaTeX environment structure. You get `\begin{env}`,`blah`, `\end{env}` on three separate lines, with `env` selected. Change `env` to whatever environment you want, then hit Tab to move to the end of the environment.
 
 These commands also work if there is no selection. In this case, they try to do the right thing; for example, `C-l C-e` gives `\emph{}` with the cursor between the curly braces.
+
+## Project Files
+
+LaTeXTools has some support for "project files": local per-project configuration files that support configuring settings specific to each project. The way this is currently implemented, each folder in the Atom project (a single window) can have up to one LaTeXTools configuration file, called `.latextools` with an extension indicating the type of contents of the file. See the [section on supported file types](#supported-file-types) for details on the supported file types.
+
+Inside the project file should be a LaTeXTools configuration settings in the same format as Atom configuration files. Note that LaTeXTools settings are all built off of a `latextools` objects. Settings not in the `latextools` object except the setting `TEXroot` (on which more below) which may be outside the `latextools` object.
+
+For example:
+
+```cson
+latextools:
+	keepFocus: True
+TEXroot: root_file.tex
+```
+
+### TEXroot
+
+Project files support a key called `TEXroot` which may be stored in the `latextools` config object or outside of it. This determines the root file in a way similar to the `%!TEX root` magic comment. If this setting is set to an absolute path, it will be used as is. If it is set to a relative path it will be resolved relative to the directory containing the matching project file.
+
+### Supported File Types
+
+The following file types are supported as LaTeXTools project files:
+
+| Extension | File Type |
+| `.cson` | CSON file |
+| `.json` | JSON file |
+| `.js` | JSON file|
+| `.yaml` | YAML file |
+| `.yml` | YAML file |
+
+These should be the extension of a file called `.latextools` so, e.g. `.latextools.cson`, `.latextools.json`, etc. Note that `.latextools` by itself will be ignored.
+
+LaTeXTools project files will be found in the order listed so `.latextools.cson` overrides `.latextools.json`, etc.

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,9 @@
+{
+  "max_line_length": {
+    "value": 80,
+    "level": "warn"
+  },
+  "no_backticks": {
+    "level": "ignore"
+  }
+}

--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -1,4 +1,4 @@
-{LTool,get_tex_root} = require './ltutils'
+{LTool} = require './ltutils'
 {exec} = require 'child_process'
 path = require 'path'
 fs = require 'fs'
@@ -79,7 +79,7 @@ class Builder extends LTool
     if te.isModified()
       te.save()
 
-    fname = get_tex_root(te)
+    fname = @getTeXRoot(te)
 
     parsed_fname = path.parse(fname)
 
@@ -92,7 +92,7 @@ class Builder extends LTool
       multiValues: ['option'],
       keyMaps: {'ts-program': 'program'}
 
-    user_options = atom.config.get("latextools.builderSettings.options")
+    user_options = @getConfig("latextools.builderSettings.options", te)
     user_options = user_options.concat directives.option
 
     # Special case: no default options, no user options give [undefined]
@@ -107,7 +107,7 @@ class Builder extends LTool
     if directives.program in whitelist
       user_program = directives.program
     else
-      user_program = atom.config.get("latextools.builderSettings.program")
+      user_program = @getConfig("latextools.builderSettings.program", te)
 
     # prepare the build console
     @ltConsole.show()
@@ -122,7 +122,7 @@ class Builder extends LTool
       current_path = process.env.Path
     else
       current_path = process.env.PATH
-    texpath = atom.config.get("latextools." + process.platform + ".texpath")
+    texpath = @getConfig("latextools.#{process.platform}.texpath", te)
     @ltConsole.addContent("Platform: #{process.platform}; texpath: #{texpath}")
     cmd_env = process.env
     if texpath
@@ -131,7 +131,7 @@ class Builder extends LTool
 
     @ltConsole.addContent("Processing file #{filebase} (#{filename}) in directory #{filedir}")
 
-    builder = atom.config.get("latextools.builder")
+    builder = @getConfig("latextools.builder", te)
     builder = "texify-latexmk" if builder not in ["texify-latexmk"]
 
     # Built-in processing via texify or latexmk
@@ -140,7 +140,7 @@ class Builder extends LTool
       # first, get command to execute, with options
       command =
         if process.platform is "win32" and
-            atom.config.get("latextools.win32.distro") isnt "texlive"
+            @getConfig("latextools.win32.distro", te) isnt "texlive"
           @texify(filedir, filebase, filename, user_options, user_program)
         else
           @latexmk(filedir, filebase, filename, user_options, user_program)

--- a/lib/commands/delete-temp-files.coffee
+++ b/lib/commands/delete-temp-files.coffee
@@ -1,4 +1,3 @@
-{get_tex_root} = require '../ltutils'
 {Directory} = require 'atom'
 fs = require 'fs'
 path = require 'path'
@@ -10,11 +9,11 @@ module.exports = (te) ->
     )
     return
 
-  rootFile = get_tex_root(te)
+  rootFile = @getTeXRoot(te)
   directory = new Directory(path.dirname(rootFile))
 
-  tempFileExts = atom.config.get('latextools.temporaryFileExtensions')
-  ignoredFolders = atom.config.get('latextools.temporaryFilesIgnoredFolders')
+  tempFileExts = @getConfig('latextools.temporaryFileExtensions')
+  ignoredFolders = @getConfig('latextools.temporaryFilesIgnoredFolders')
 
   fileHandler = (file) ->
     new Promise (resolve, reject) ->

--- a/lib/completion-manager.coffee
+++ b/lib/completion-manager.coffee
@@ -1,4 +1,4 @@
-{LTool,get_tex_root,find_in_files,is_file} = require './ltutils'
+{LTool,find_in_files,is_file} = require './ltutils'
 LTSimpleSelectList = require './views/ltsimple-select-list-view'
 LTTwoLineSelectList = require './views/lttwo-line-select-list-view'
 #get_ref_completions = require './get-ref-completions'
@@ -93,7 +93,7 @@ class CompletionManager extends LTool
   sel2_view: null
   sel_panel: null
 
-  constructor: (@ltconsole) ->
+  constructor: ->
     super
     @sel_view = new LTSimpleSelectList
     @sel2_view = new LTTwoLineSelectList
@@ -120,12 +120,12 @@ class CompletionManager extends LTool
 
     # TODO: pass initial match to select list
 
-    if (keybinding or atom.config.get("latextools.refAutoTrigger")) and
+    if (keybinding or @getConfig("latextools.refAutoTrigger", te)) and
         m = ref_rx_rev.exec(line)
       console.log("found match")
       @refComplete(te)
       return true
-    else if (keybinding or atom.config.get("latextools.citeAutoTrigger")) and
+    else if (keybinding or @getConfig("latextools.citeAutoTrigger", te)) and
         m = cite_rx_rev.exec(line)
       console.log("found match")
       console.log(m)
@@ -157,15 +157,17 @@ class CompletionManager extends LTool
 
 
   refComplete: (te) ->
-
-    fname = get_tex_root(te) # pass TextEditor, thanks to ig0777's patch
+    # pass TextEditor, thanks to ig0777's patch
+    fname = @getTeXRoot(te)
 
     parsed_fname = path.parse(fname)
 
     filedir = parsed_fname.dir
     filebase = parsed_fname.base  # name only includes the name (no dir, no ext)
 
-    labels = find_in_files(filedir, filebase, /\\label\{([^\}]+)\}/g)
+    labels = find_in_files.bind(@latextools)(
+      filedir, filebase, /\\label\{([^\}]+)\}/g
+    )
 
     # TODO add partially specified label to search field
     @sel_view.setItems(labels)
@@ -181,8 +183,7 @@ class CompletionManager extends LTool
 
 
   citeComplete: (te) ->
-
-    fname = get_tex_root(te)
+    fname = @getTeXRoot(te)
 
     parsed_fname = path.parse(fname)
 
@@ -190,7 +191,9 @@ class CompletionManager extends LTool
     filebase = parsed_fname.base  # name only includes the name (no dir, no ext)
 
     bib_rx = /\\(?:bibliography|nobibliography|addbibresource)\{([^\}]+)\}/g
-    raw_bibs = find_in_files(filedir, filebase, bib_rx)
+    raw_bibs = find_in_files.bind(@latextools)(
+      filedir, filebase, bib_rx
+    )
 
     # Split multiple bib files
     bibs = []
@@ -220,7 +223,7 @@ class CompletionManager extends LTool
     for b in bibs
       [keywords, titles, authors, years, authors_short, titles_short, journals] = get_bib_completions(b)
       # TODO formatting here
-      item_fmt = atom.config.get("latextools.citePanelFormat")
+      item_fmt = @getConfig("latextools.citePanelFormat", te)
 
       if item_fmt.length != 2
         atom.notifications.addError(

--- a/lib/project-manager.coffee
+++ b/lib/project-manager.coffee
@@ -1,0 +1,89 @@
+{Emitter, Disposable, CompositeDisposable} = require 'atom'
+{Project} = require './project'
+
+module.exports.ProjectManager =
+class ProjectManager extends Disposable
+  constructor: ->
+    @disposables = new CompositeDisposable
+    @disposables.add @emitter = new Emitter
+    @disposables.add atom.config.onDidChange 'latextools.useProjectFiles',
+      ({newValue}) =>
+        if newValue is true
+          @loadProjects()
+        else
+          @dispose()
+
+    @loadProjects() if atom.config.get('latextools.useProjectFiles')
+
+
+  dispose: ->
+    @disposables.dispose()
+    @projectFiles = undefined
+
+  getProject: (path) ->
+    unless path?
+      if @projectFiles?
+        keys = Object.keys(@projectFiles)
+        if keys.length is 1
+          return @projectFiles[keys[0]]
+        else if @projectFiles?
+          atom.notifications.addWarning(
+            'Cannot determine project for unsaved buffer as more than one ' +
+            'project is currently opened.'
+          )
+      return undefined
+
+    projects = Object.keys(@projectFiles).filter (p) ->
+      if p?
+        path.startsWith(p)
+      else
+        false
+
+    switch
+      when not projects
+        undefined
+      when projects.length is 1
+        @projectFiles[projects[0]]
+      else
+        # take the longest matching project path which should be the most
+        # local to the project, e.g. comparing /path/to/main to
+        # /path/to/subfolder whereas /path/to/subfolder/subsubfolder will've
+        # alreadyg been filtered out
+        @projectFiles[projects.reduce ((p, c) ->
+          if c.length > p.length
+            c
+          else
+            p
+        ), '']
+
+  onDidAddProject: (callback) ->
+    @emitter.on 'did-add', callback
+
+  # note that this *only* emits the project path
+  onDidRemoveProject: (callback) ->
+    @emitter.on 'did-remove', callback
+
+  # -- Private API --
+  loadProjects: ->
+    @projectFiles = {}
+    for path in atom.project.getPaths()
+      @disposables.add @projectFiles[path] = new Project(path)
+      @emitter.emit 'did-add', @projectFiles[path]
+
+    @disposables.add atom.project.onDidChangePaths (newPaths) =>
+      projectPaths = Object.keys(@projectFiles)
+      addedPaths = newPaths.filter (it) ->
+        projectPaths.indexOf(it) is -1
+      removedPaths = @projectPaths.filter (it) ->
+        newPaths.indexOf(it) is -1
+
+      for path in removedPaths
+        removed = @projectFiles[path]
+        @disposables.remove removed
+        removed.dispose()
+        @projectFiles[path] = undefined
+        @emitter.emit 'did-remove', path
+
+      for path in addedPaths
+        @disposables.add @projectFiles[path] = new Project(path)
+        @emitter.emit 'did-add', @projectFiles[path]

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -1,0 +1,120 @@
+{Emitter, File, Directory, CompositeDisposable, Disposable} = require 'atom'
+{getValueAtKeyPath} = require 'key-path-helpers'
+fs = require 'fs'
+path = require 'path'
+
+SUPPORTED_EXTENSIONS =
+  cson: (contents) ->
+    CSON = require 'cson-parser'
+    CSON.parse(contents)
+
+  json: (contents) ->
+    # JSON.minify adds supports for comments
+    JSON.minify = require 'node-json-minify'
+    JSON.parse(JSON.minify(contents))
+
+  js: (contents) -> @json(contents)
+
+  yml: (contents) ->
+    YAML = require 'js-yaml'
+    YAML.safeLoad contents
+
+  yaml: (contents) -> @yml(contents)
+
+FILE_MATCHER = new RegExp(
+  "\\.latextools\\.(?:#{Object.keys(SUPPORTED_EXTENSIONS).join('|')})"
+)
+
+module.exports.Project =
+class Project extends Disposable
+  constructor: (@cwd) ->
+    @emitter = new Emitter
+    @config = {}
+
+    candidates = Object.keys(SUPPORTED_EXTENSIONS).map((ext) =>
+      path.join(@cwd, ".latextools.#{ext}")
+    ).filter(fs.existsSync)
+
+    if candidates? and candidates.length > 0
+      @configFile = candidates[0]
+      @loadConfig()
+    else
+      @addDirWatcher()
+
+  get: (keyPath) ->
+    getValueAtKeyPath(@config, keyPath)
+
+  onDidLoad: (callback) ->
+    @emitter.on 'did-load', callback
+
+  onDidUnload: (callback) ->
+    @emitter.on 'did-unload', callback
+
+  onDidUpdate: (callback) ->
+    @emitter.on 'did-update', callback
+
+  dispose: ->
+    @unloadConfig()
+    @fileDisposable?.dispose()
+    @dirDisposable?.dispose()
+    @emitter.dispose()
+
+  # -- Private API --
+  addFileWatcher: ->
+    return unless @configFile?
+
+    @file = new File(@configFile)
+    @fileDisposable = new CompositeDisposable
+    @fileDisposable.add @file.onDidChange =>
+      @updateConfig()
+      @emitter.emit 'did-update', @
+    @fileDisposable.add @file.onDidDelete =>
+      @unloadConfig()
+      @addDirWatcher()
+    @fileDisposable.add @file.onDidRename =>
+      if FILE_MATCHER.exec @file.getBaseName()
+        @configFile = @file.getPath()
+        @updateConfig()
+        @emitter.emit 'did-update', @
+      else
+        @unloadConfig()
+
+  addDirWatcher: ->
+    return if @configFile?
+
+    @dir = new Directory(@cwd)
+    @dirDisposable = new CompositeDisposable
+    @dirDisposable.add @dir.onDidChange =>
+      for entry in @dir.getEntriesSync()
+        continue unless entry instanceof File
+        continue unless FILE_MATCHER.exec(entry.getBaseName())
+        @configFile = entry.getPath()
+        @loadConfig()
+
+        @dirDisposable.dispose()
+        @dir = null
+        break
+
+  loadConfig: ->
+    @addFileWatcher()
+    @updateConfig()
+    @emitter.emit 'did-load', @
+
+  updateConfig: ->
+    return unless @configFile?
+    contents = "#{fs.readFileSync @configFile}"
+    try
+      config = SUPPORTED_EXTENSIONS[path.extname(@configFile)[1..]](contents)
+      config = {latextools: config} unless 'latextools' in Object.keys(config)
+      @config = config
+    catch
+      @config = {}
+
+  unloadConfig: ->
+    @configFile = null
+    @config = {}
+    @file = null
+    @fileDisposable?.dispose()
+    @fileDisposable = null
+
+    @emitter.emit 'did-unload', @

--- a/lib/snippet-manager.coffee
+++ b/lib/snippet-manager.coffee
@@ -1,4 +1,4 @@
-{LTool,get_tex_root} = require './ltutils'
+{LTool} = require './ltutils'
 
 module.exports =
 

--- a/lib/viewer.coffee
+++ b/lib/viewer.coffee
@@ -1,4 +1,4 @@
-{LTool, get_tex_root, is_file} = require './ltutils'
+{LTool, is_file} = require './ltutils'
 {exec, execFile} = require 'child_process'
 path = require 'path'
 
@@ -23,12 +23,12 @@ class Viewer extends LTool
     # this is the file currently being edited, which is where the user wants to jump to
     current_file = te.getPath()
     # it need not be the master file, so we look for that, too
-    master_file = get_tex_root(te)
+    master_file = @getTeXRoot(te)
 
     parsed_master = path.parse(master_file)
     parsed_current = path.parse(current_file)
 
-    tex_exts = atom.config.get("latextools.texFileExtensions")
+    tex_exts = @getConfig("latextools.texFileExtensions", te)
     if parsed_master.ext in tex_exts && parsed_current.ext in tex_exts
       master_path_no_ext = path.join(parsed_master.dir, parsed_master.name)
 
@@ -50,10 +50,10 @@ class Viewer extends LTool
         )
         return
 
-      forward_sync = atom.config.get("latextools.forwardSync")
-      keep_focus = atom.config.get("latextools.keepFocus")
+      forward_sync = @getConfig("latextools.forwardSync", te)
+      keep_focus = @getConfig("latextools.keepFocus", te)
 
-      viewerName = atom.config.get("latextools.viewer")
+      viewerName = @getConfig("latextools.viewer", te)
       viewerClass = @viewerRegistry.get viewerName
 
       @ltConsole.addContent("Using viewer #{viewerName}")
@@ -66,7 +66,7 @@ class Viewer extends LTool
         viewerClass = @viewerRegistry.get 'default'
         return unless viewerClass?
 
-      viewer = new viewerClass(@ltConsole)
+      viewer = new viewerClass(@latextools)
 
       if forward_sync
         viewer.forwardSync pdf_file, current_file, row, col,

--- a/lib/viewers/base-viewer.coffee
+++ b/lib/viewers/base-viewer.coffee
@@ -1,11 +1,8 @@
 {execFile} = require 'child_process'
-{quote} = require '../ltutils'
+{quote, LTool} = require '../ltutils'
 
 module.exports =
-class BaseViewer
-  constructor: (ltConsole) ->
-    @ltConsole = ltConsole
-
+class BaseViewer extends LTool
   forwardSync: (pdfFile, texFile, line, col, opts = {}) ->
     throw
       name: "Not Implemented Error"

--- a/lib/viewers/sumatra-viewer.coffee
+++ b/lib/viewers/sumatra-viewer.coffee
@@ -3,7 +3,7 @@ BaseViewer = require './base-viewer'
 module.exports =
 class SumatraViewer extends BaseViewer
   _getArgs = ->
-    [atom.config.get("latextools.win32.sumatra"), "-reuse-instance"]
+    [@getConfig("latextools.win32.sumatra"), "-reuse-instance"]
 
   forwardSync: (pdfFile, texFile, line, col, opts = {}) ->
     args = _getArgs()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "fuzzaldrin": "^2.1.0"
+    "cson-parser": "^1.3.3",
+    "fuzzaldrin": "^2.1.0",
+    "js-yaml": "^3.6.1",
+    "key-path-helpers": "^0.4.0",
+    "node-json-minify": "^1.0.0"
   },
   "consumedServices": {
     "snippets": {

--- a/spec/fixtures/project/add-project-file/data/.latextools.cson
+++ b/spec/fixtures/project/add-project-file/data/.latextools.cson
@@ -1,0 +1,2 @@
+latextools:
+  type: "cson"

--- a/spec/fixtures/project/cson-project/.latextools.cson
+++ b/spec/fixtures/project/cson-project/.latextools.cson
@@ -1,0 +1,2 @@
+latextools:
+  type: "cson"

--- a/spec/fixtures/project/js-project/.latextools.js
+++ b/spec/fixtures/project/js-project/.latextools.js
@@ -1,0 +1,6 @@
+{
+  "latextools":
+  {
+    "type": "js"
+  }
+}

--- a/spec/fixtures/project/json-project/.latextools.json
+++ b/spec/fixtures/project/json-project/.latextools.json
@@ -1,0 +1,6 @@
+{
+  "latextools":
+  {
+    "type": "json"
+  }
+}

--- a/spec/fixtures/project/update-project-file/.latextools.cson
+++ b/spec/fixtures/project/update-project-file/.latextools.cson
@@ -1,0 +1,2 @@
+latextools:
+	type: "json"

--- a/spec/fixtures/project/with-latextools/.latextools.cson
+++ b/spec/fixtures/project/with-latextools/.latextools.cson
@@ -1,0 +1,4 @@
+latextools:
+  type: "cson"
+
+type: "cson"

--- a/spec/fixtures/project/without-latextools/.latextools.cson
+++ b/spec/fixtures/project/without-latextools/.latextools.cson
@@ -1,0 +1,1 @@
+type: "cson"

--- a/spec/fixtures/project/yaml-project-yaml-ext/.latextools.yaml
+++ b/spec/fixtures/project/yaml-project-yaml-ext/.latextools.yaml
@@ -1,0 +1,3 @@
+---
+  latextools:
+    type: yaml

--- a/spec/fixtures/project/yaml-project/.latextools.yml
+++ b/spec/fixtures/project/yaml-project/.latextools.yml
@@ -1,0 +1,3 @@
+---
+  latextools:
+    type: yaml

--- a/spec/getConfig-spec.coffee
+++ b/spec/getConfig-spec.coffee
@@ -1,0 +1,59 @@
+latextools = require '../lib/latextools'
+{getValueAtKeyPath} = require 'key-path-helpers'
+
+class ProjectDummy
+  constructor: ->
+    @config = {}
+
+  get: (keyPath) ->
+    getValueAtKeyPath(@config, keyPath)
+
+describe 'getConfig', ->
+  beforeEach ->
+    atom.config.set 'latextools.useProjectFiles', true
+    latextools.requireIfNeeded = () ->
+    latextools.projectManager = new Object
+      getProject: => @project
+    @project = new ProjectDummy
+    @te = new Object getPath: -> ''
+
+  it 'should return project setting', ->
+    @project.config = latextools: value: 'match'
+    result = latextools.getConfig 'latextools.value', @te
+    expect(result).toEqual 'match'
+
+  describe 'iteraction with atom.config', ->
+    afterEach ->
+      atom.config.unset 'latextools.value'
+
+    it 'should override the atom setting if project setting set', ->
+      atom.config.set 'latextools.value', 'atom.config', save: false
+      @project.config = latextools: value: 'project.config'
+
+      result = latextools.getConfig 'latextools.value', @te
+      expect(result).toEqual 'project.config'
+
+    it 'should return the atom setting if project setting unset', ->
+      atom.config.set 'latextools.value', 'atom.config', save: false
+      result = latextools.getConfig 'latextools.value', @te
+      expect(result).toEqual 'atom.config'
+
+    it 'should return the atom setting if project setting undefined', ->
+      atom.config.set 'latextools.value', 'atom.config', save: false
+      @project.config = latextools: value: undefined
+
+      result = latextools.getConfig 'latextools.value', @te
+      expect(result).toEqual 'atom.config'
+
+    it 'should return the atom setting if project not found', ->
+      atom.config.set 'latextools.value', 'atom.config', save: false
+      latextools.projectManager.getProject = -> undefined
+
+      result = latextools.getConfig 'latextools.value', @te
+      expect(result).toEqual 'atom.config'
+
+    it 'should return the atom setting if useProjectFiles is false', ->
+      atom.config.set 'latextools.useProjectFiles', false
+      atom.config.set 'latextools.value', 'atom.config', save: false
+      result = latextools.getConfig 'latextools.value', @te
+      expect(result).toEqual 'atom.config'

--- a/spec/parsers/tex-directive-parser-spec.coffee
+++ b/spec/parsers/tex-directive-parser-spec.coffee
@@ -149,7 +149,7 @@ describe 'TeXCommentParser', ->
       expect(result.options).toBeUndefined()
 
     it 'should support reading from a file specified as a path', ->
-      fixturesPath = path.join atom.project.getPaths()[0], 'parsers', \
+      fixturesPath = path.join __dirname, '..', 'fixtures', 'parsers',
         'tex-directive-parser'
       # this is necessary for tests to run locally from symlinked directory
       fixturesPath = fs.realpathSync(fixturesPath)

--- a/spec/project-manager-spec.coffee
+++ b/spec/project-manager-spec.coffee
@@ -1,0 +1,62 @@
+{ProjectManager} = require '../lib/project-manager'
+
+describe 'ProjectManager', ->
+  describe 'toggle activation', ->
+    beforeEach ->
+      @projectManager = new ProjectManager
+
+    afterEach ->
+      @projectManager?.dispose()
+
+    it 'should load projects if setting set to true', ->
+      spyOn(@projectManager, 'loadProjects')
+
+      runs ->
+        atom.config.set 'latextools.useProjectFiles', true
+
+      waitsFor 'did-load event', => @projectManager.loadProjects.callCount > 0
+
+      runs ->
+        expect(@projectManager.loadProjects).toHaveBeenCalled()
+
+    it 'should unload projects if setting is set to false', ->
+      spyOn(@projectManager, 'dispose').andCallThrough()
+
+      runs ->
+        atom.config.set 'latextools.useProjectFiles', false
+
+      waitsFor 'did-load event', => @projectManager.dispose.callCount > 0
+
+      runs ->
+        expect(@projectManager.dispose).toHaveBeenCalled()
+
+  describe 'initial state', ->
+    it 'should call loadProjects if useProjectFiles is true', ->
+      atom.config.set 'latextools.useProjectFiles', true
+      spyOn(ProjectManager::, 'loadProjects')
+      @projectManager = new ProjectManager
+      expect(ProjectManager::loadProjects).toHaveBeenCalled()
+
+    it 'should not call laodProjects if useProjectFiles is false', ->
+      atom.config.set 'latextools.useProjectFiles', false
+      spyOn(ProjectManager::, 'loadProjects')
+      @projectManager = new ProjectManager
+      expect(ProjectManager::loadProjects).not.toHaveBeenCalled()
+
+  describe 'getProject', ->
+    beforeEach ->
+      @projectManager = new ProjectManager
+
+    afterEach ->
+      @projectManager?.dispose()
+
+    describe 'no path provided', ->
+      it 'should return undefined if no project files exist', ->
+        expect(@projectManager.getProject()).toBeUndefined()
+
+      it 'should return project if a single project exists', ->
+        project = {}
+        @projectManager.projectFiles =
+          '/tmp': project
+
+        expect(@projectManager.getProject()).toBe project

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -1,0 +1,157 @@
+{Project} = require '../lib/project'
+fs = require 'fs'
+path = require 'path'
+
+describe 'Project', ->
+  afterEach ->
+    @project?.dispose()
+
+  it 'should load a JSON project file', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'json-project'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools.type).toEqual 'json'
+
+  it 'should load a JSON project file with js extension', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'js-project'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools.type).toEqual 'js'
+
+  it 'should load a CSON project file', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'cson-project'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools.type).toEqual 'cson'
+
+  it 'should load a YAML project file', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'yaml-project'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools.type).toEqual 'yaml'
+
+  it 'should load a YAML project file with yaml extension', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'yaml-project-yaml-ext'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools.type).toEqual 'yaml'
+
+  it 'should make configuration properties available via get()', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'cson-project'
+
+    @project = new Project(fixturePath)
+    expect(@project.get('latextools.type')).toEqual 'cson'
+
+  it 'should wrap config in latextools object', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'without-latextools'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools).toBeDefined()
+    expect(@project.config.latextools.type).toEqual 'cson'
+
+  it 'should not wrap config in latextools if latextools object defined', ->
+    fixturePath = path.join __dirname,  'fixtures',
+      'project', 'with-latextools'
+
+    @project = new Project(fixturePath)
+    expect(@project.config.latextools).toBeDefined()
+    expect(@project.config.type).toEqual 'cson'
+
+  describe 'adding project file', ->
+    beforeEach ->
+      @fixturePath = path.join __dirname,  'fixtures',
+        'project', 'add-project-file'
+      @copiedFile = path.join @fixturePath, '.latextools.cson'
+
+      fs.unlinkSync(@copiedFile) if fs.existsSync(@copiedFile)
+
+    afterEach ->
+      fs.unlinkSync(@copiedFile) if fs.existsSync(@copiedFile)
+
+    it 'should load a project file when added', (done) ->
+      [loadSpy] = []
+
+      runs ->
+        @project = new Project(@fixturePath)
+        @project.onDidLoad loadSpy = jasmine.createSpy('loadHandler')
+
+        expect(@project.config).toEqual {}
+
+        fs.writeFileSync @copiedFile,
+          fs.readFileSync path.join(@fixturePath, 'data/.latextools.cson')
+
+      waitsFor 'did-load event', -> loadSpy.callCount > 0
+
+      runs ->
+        expect(@project.config).not.toEqual {}
+
+  describe 'removing a project file', ->
+    beforeEach ->
+      @fixturePath = path.join __dirname,  'fixtures',
+        'project', 'remove-project-file'
+      @configFile = path.join @fixturePath, '.latextools.cson'
+
+      unless fs.existsSync(@fixturePath)
+        fs.mkdirSync(@fixturePath)
+
+      unless fs.existsSync(@configFile)
+        fs.writeFileSync @configFile,
+          """latextools:
+          \ttype: "cson"
+          """
+
+    afterEach ->
+      fs.rmdirSync @fixturePath
+
+    it 'should remove project settings when file deleted', ->
+      [unloadSpy] = []
+
+      runs ->
+        @project = new Project(@fixturePath)
+        @project.onDidUnload unloadSpy = jasmine.createSpy('unloadHandler')
+
+        expect(@project.config).not.toEqual {}
+
+        fs.unlinkSync @configFile
+
+      waitsFor 'did-unload event', -> unloadSpy.callCount > 0
+
+      runs ->
+        expect(@project.config).toEqual {}
+
+  describe 'updating a project file', ->
+    beforeEach ->
+      @fixturePath = path.join __dirname,  'fixtures',
+        'project', 'update-project-file'
+      @configFile = path.join @fixturePath, '.latextools.cson'
+
+      fs.writeFileSync @configFile,
+        """latextools:
+        \ttype: "cson"
+        """
+
+    it 'should update project settings when file updated', ->
+      [updateSpy] = []
+
+      runs ->
+        @project = new Project(@fixturePath)
+        @project.onDidUpdate updateSpy = jasmine.createSpy('updateHandler')
+
+        expect(@project.config.latextools.type).toEqual 'cson'
+
+        fs.writeFileSync @configFile,
+          """latextools:
+          \ttype: "json"
+          """
+
+      waitsFor 'did-update event', -> updateSpy.callCount > 0
+
+      runs ->
+        expect(@project.config.latextools.type).toEqual 'json'


### PR DESCRIPTION
Adds support for project files to latextools which allows configuration on a per-project basis. It's main use right now is to set the `TEXroot` without needing to use a magic comment, but I envision being able to use them similar to how we use project files on Sublime Text (especially pending #86).

A project file is a small configuration file, which can be formatted either as CSON, JSON, or YAML, consisting of configuration data that basically matches Atom's configuration format. Project files are called `.latextools.cson` or `.latextools.json`, etc. and must be placed in the directory open in the current Atom project—usually this means a directory open in the Tree View. If they are placed in a subfolder, they will be ignored, unless that subfolder is separately open as a directory in the Tree View. This a concession to performance / sanity. Any setting that can be set in LaTeXTools configuration can be set in the project file, sans the nice GUI, which means its important that you're careful only to select values LaTeXTools understands.

Basically, the main extra is support for a configuration value called either `TEXroot` or `latextools.TEXroot` which specifies the file to treat as the main document. This can be specified either as an absolute or relative path. If a relative path, it is resolved relative to the directory containing the project file.

This should resolve #71.