### PR TITLE
Hide menu items in non-latex files.

### DIFF
--- a/menus/latextools.cson
+++ b/menus/latextools.cson
@@ -1,6 +1,6 @@
 # See https://atom.io/docs/latest/hacking-atom-package-word-count#menus for more details
 'context-menu':
-  'atom-text-editor': [
+  'atom-text-editor[data-grammar*="text tex"': [
     {
       'label': 'Jump to PDF'
       'command': 'latextools:jump-to-pdf'


### PR DESCRIPTION
Hide menu items in non-latex files, in order not to clutter up the editor.