### PR TITLE
remove undefined from options

### DIFF
--- a/lib/builder.coffee
+++ b/lib/builder.coffee
@@ -95,9 +95,8 @@ class Builder extends LTool
     user_options = atom.config.get("latextools.builderSettings.options")
     user_options = user_options.concat directives.option
 
-    # Special case: no default options, no user options give [undefined]
-    if user_options.length==1 && user_options[0] == undefined
-      user_options = []
+    # Filter out [undefined] when directives.option or user_options are empty
+    user_options = user_options.filter (x) -> x isnt undefined
 
     # white-list the selectable programs
     # on Windows / miktex, allow both pdftex, etc and pdflatex


### PR DESCRIPTION
The current solution: (builder.coffee l.98)

```coffeescript
# Special case: no default options, no user options give [undefined]
if user_options.length==1 && user_options[0] == undefined
  user_options = []
```

for removing undefined has flaws: when directives.options is empty and user_options is not, then this lines yields
```coffeescript
user_options = user_options.concat directives.option
# e.g. user_options = ['-shell-escape'] and directives.option = [undefined]
# results in user_options = ['--shell-escape', undefined] => undefined remains ...
```
as stated in https://github.com/msiniscalchi/atom-latextools/issues/162

This is a fix based on filtering out any occurrence of undefined in the array user_options.